### PR TITLE
ci: add workflow to block PRs behind main

### DIFF
--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -1,0 +1,81 @@
+name: PR Branch Status Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-branch-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+      
+      - name: Check if PR is behind base
+        id: check
+        run: |
+          # Get base and head refs
+          BASE="${{ github.event.pull_request.base.ref }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          
+          # Count commits behind and ahead
+          COUNTS=$(git rev-list --left-right --count origin/$BASE...$HEAD)
+          BEHIND=$(echo $COUNTS | cut -d' ' -f1)
+          AHEAD=$(echo $COUNTS | cut -d' ' -f2)
+          
+          echo "behind=$BEHIND" >> $GITHUB_OUTPUT
+          echo "ahead=$AHEAD" >> $GITHUB_OUTPUT
+          
+          # Log the status
+          echo "Branch Status:"
+          echo "  - $BEHIND commits behind $BASE"
+          echo "  - $AHEAD commits ahead of $BASE"
+          
+          # Fail if behind
+          if [ "$BEHIND" -gt 0 ]; then
+            echo "::error::This PR is $BEHIND commits behind $BASE. Please rebase or merge $BASE into your branch."
+            exit 1
+          else
+            echo "::notice::Branch is up to date with $BASE ($AHEAD commits ahead)"
+          fi
+      
+      - name: Add PR comment
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const behind = '${{ steps.check.outputs.behind }}';
+            const ahead = '${{ steps.check.outputs.ahead }}';
+            const base = '${{ github.event.pull_request.base.ref }}';
+            
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Branch Out of Date
+
+This PR is **${behind} commits behind** \`${base}\`.
+
+**Status:**
+- ${behind} commits behind \`${base}\`  
+- ${ahead} commits ahead of \`${base}\`
+
+**Action Required:**
+Please update your branch to include the latest changes from \`${base}\`:
+
+\`\`\`bash
+git checkout ${{ github.event.pull_request.head.ref }}
+git merge origin/${base}
+# Or for a cleaner history:
+git rebase origin/${base}
+\`\`\`
+
+Once updated, this check will pass automatically.`
+            });


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds a GitHub Actions workflow that prevents PRs from being merged if they are behind the base branch. The workflow runs on PR open, sync, and reopen events, calculates commits behind/ahead using `git rev-list`, and fails the check with a helpful comment if the PR is out of date.

- Enforces branch hygiene by blocking outdated PRs
- Provides clear feedback with commit counts and rebase/merge instructions
- Uses GitHub Actions best practices with `actions/checkout@v4` and `actions/github-script@v7`
- **Issue:** Missing closing semicolon at end of script block (line 82)

<h3>Confidence Score: 4/5</h3>


- Safe to merge after fixing the syntax error at line 82
- The workflow logic is sound and uses correct git commands for branch comparison. The only issue is a minor syntax error (missing closing semicolon) that would prevent the workflow from running correctly. Once fixed, this will work as intended.
- `.github/workflows/pr-branch-check.yml` needs the syntax fix before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/pr-branch-check.yml | Adds GitHub Actions workflow to enforce PRs are up-to-date with base branch before merging |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PR as Pull Request
    participant GHA as GitHub Actions
    participant Git as Git Repository
    participant API as GitHub API
    
    PR->>GHA: Trigger (opened/synchronize/reopened)
    GHA->>Git: Checkout PR head SHA
    GHA->>Git: Fetch base branch
    GHA->>Git: git rev-list --left-right --count
    Git-->>GHA: Return commits behind/ahead
    
    alt PR is behind base
        GHA->>GHA: Set outputs (behind, ahead)
        GHA->>GHA: Exit with error code 1
        GHA->>API: Create comment on PR
        API-->>PR: Post "Branch Out of Date" message
        GHA-->>PR: ❌ Check Failed
    else PR is up to date
        GHA->>GHA: Set outputs (behind=0, ahead)
        GHA->>GHA: Log success notice
        GHA-->>PR: ✅ Check Passed
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated verification to ensure PR branches are synchronized with the base branch.
  * PR comments provide guidance for updating branches when they fall behind.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->