### PR TITLE
cryptographic-payment-receipts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ CHAIN_ID=8453
 USDC_TOKEN_ADDRESS=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 #dummy
 PAYMENT_AMOUNT=0.001
 
+# Receipt Configuration
+# Time-to-live for receipts in seconds (default: 86400 = 24 hours)
+RECEIPT_TTL=86400
+
 # Service URLs (for Docker/production)
 VERIFIER_URL=http://127.0.0.1:3002
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -11,7 +11,6 @@ require (
 )
 
 require (
-	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -10,9 +10,12 @@ require (
 )
 
 require (
+	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/ethereum/go-ethereum v1.16.7 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
@@ -20,6 +23,7 @@ require (
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.18.0 // indirect
+	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,6 +3,7 @@ module gateway
 go 1.24.4
 
 require (
+	github.com/ethereum/go-ethereum v1.16.7
 	github.com/gin-contrib/cors v1.7.6
 	github.com/gin-gonic/gin v1.11.0
 	github.com/google/uuid v1.6.0
@@ -15,7 +16,6 @@ require (
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
-	github.com/ethereum/go-ethereum v1.16.7 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.9 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,3 +1,5 @@
+github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
+github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/bytedance/sonic v1.14.0 h1:/OfKt8HFw0kh2rj8N0F6C/qPGRESq0BbaNZgcNXXzQQ=
 github.com/bytedance/sonic v1.14.0/go.mod h1:WoEbx8WTcFJfzCe0hbmyTGrfjt8PzNEBdxlNUO24NhA=
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
@@ -7,6 +9,11 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
+github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+github.com/ethereum/go-ethereum v1.16.7 h1:qeM4TvbrWK0UC0tgkZ7NiRsmBGwsjqc64BHo20U59UQ=
+github.com/ethereum/go-ethereum v1.16.7/go.mod h1:Fs6QebQbavneQTYcA39PEKv2+zIjX7rPUZ14DER46wk=
 github.com/gabriel-vasile/mimetype v1.4.9 h1:5k+WDwEsD9eTLL8Tz3L0VnmVh9QxGjRmjBvAG7U/oYY=
 github.com/gabriel-vasile/mimetype v1.4.9/go.mod h1:WnSQhFKJuBlRyLiKohA/2DtIlPFAbguNaG7QCHcyGok=
 github.com/gin-contrib/cors v1.7.6 h1:3gQ8GMzs1Ylpf70y8bMw4fVpycXIeX1ZemuSQIsnQQY=
@@ -32,6 +39,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
+github.com/holiman/uint256 v1.3.2/go.mod h1:EOMSn4q6Nyt9P6efbI3bueV4e1b3dGlUCXeiRV4ng7E=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -9,6 +9,7 @@ github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=

--- a/gateway/receipt.go
+++ b/gateway/receipt.go
@@ -112,7 +112,9 @@ func signReceipt(receipt Receipt) (*SignedReceipt, error) {
 	// Hash the receipt using Keccak256 (Ethereum-compatible)
 	hash := crypto.Keccak256Hash(receiptBytes)
 
-	// Sign the hash
+	// Sign the hash using ECDSA
+	// SECURITY: crypto.Sign uses constant-time operations from go-ethereum's secp256k1 implementation
+	// This prevents timing attacks that could leak private key information
 	signature, err := crypto.Sign(hash.Bytes(), privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign receipt: %w", err)

--- a/gateway/receipt.go
+++ b/gateway/receipt.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// ReceiptStore defines the interface for receipt storage implementations
+// This allows for easy swapping between in-memory, Redis, PostgreSQL, etc.
+type ReceiptStore interface {
+	Store(receipt *SignedReceipt, ttl time.Duration) error
+	Get(id string) (*SignedReceipt, error)
+	Delete(id string) error
+}
+
+// Receipt represents a cryptographic payment receipt
+type Receipt struct {
+	ID        string          `json:"id"`
+	Version   string          `json:"version"`
+	Timestamp time.Time       `json:"timestamp"`
+	Payment   PaymentDetails  `json:"payment"`
+	Service   ServiceDetails  `json:"service"`
+}
+
+// PaymentDetails contains payment-related information
+type PaymentDetails struct {
+	Payer     string `json:"payer"`
+	Recipient string `json:"recipient"`
+	Amount    string `json:"amount"`
+	Token     string `json:"token"`
+	ChainID   int    `json:"chain_id"`
+	Nonce     string `json:"nonce"`
+}
+
+// ServiceDetails contains service-related information
+type ServiceDetails struct {
+	Endpoint     string `json:"endpoint"`
+	RequestHash  string `json:"request_hash"`
+	ResponseHash string `json:"response_hash"`
+}
+
+// SignedReceipt contains the receipt and its cryptographic signature
+type SignedReceipt struct {
+	Receipt         Receipt `json:"receipt"`
+	Signature       string  `json:"signature"`
+	ServerPublicKey string  `json:"server_public_key"`
+}
+
+// GenerateReceipt creates a new receipt for a successful payment
+func GenerateReceipt(payment PaymentContext, payer string, endpoint string, reqBody, respBody []byte) (*SignedReceipt, error) {
+	receipt := Receipt{
+		ID:        generateReceiptID(),
+		Version:   "1.0",
+		Timestamp: time.Now().UTC(),
+		Payment: PaymentDetails{
+			Payer:     payer,
+			Recipient: payment.Recipient,
+			Amount:    payment.Amount,
+			Token:     payment.Token,
+			ChainID:   payment.ChainID,
+			Nonce:     payment.Nonce,
+		},
+		Service: ServiceDetails{
+			Endpoint:     endpoint,
+			RequestHash:  hashData(reqBody),
+			ResponseHash: hashData(respBody),
+		},
+	}
+
+	return signReceipt(receipt)
+}
+
+// generateReceiptID generates a unique receipt ID with "rcpt_" prefix
+func generateReceiptID() string {
+	// Generate 6 random bytes (12 hex characters)
+	bytes := make([]byte, 6)
+	if _, err := rand.Read(bytes); err != nil {
+		// Fallback to timestamp-based ID if random fails
+		// This maintains uniqueness even if entropy is exhausted
+		timestamp := time.Now().UnixNano()
+		return fmt.Sprintf("rcpt_%012x", timestamp)
+	}
+	return "rcpt_" + hex.EncodeToString(bytes)
+}
+
+// hashData computes SHA-256 hash of data and returns hex-encoded string
+func hashData(data []byte) string {
+	if len(data) == 0 {
+		return "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" // Empty hash
+	}
+	hash := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(hash[:])
+}
+
+// signReceipt signs a receipt using the server's private key
+// NOTE: Go's json.Marshal is deterministic for structs - fields are always
+// serialized in declaration order (the order they appear in the struct definition).
+// This ensures consistent signatures. Non-determinism only affects map types.
+func signReceipt(receipt Receipt) (*SignedReceipt, error) {
+	// Get server's private key
+	privateKey, err := getServerPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load server private key: %w", err)
+	}
+
+	// Serialize receipt deterministically
+	// For structs, json.Marshal always outputs fields in declaration order
+	receiptBytes, err := json.Marshal(receipt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal receipt: %w", err)
+	}
+
+	// Hash the receipt using Keccak256 (Ethereum-compatible)
+	hash := crypto.Keccak256Hash(receiptBytes)
+
+	// Sign the hash
+	signature, err := crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign receipt: %w", err)
+	}
+
+	// Get server's public key for verification
+	publicKey := privateKey.Public().(*ecdsa.PublicKey)
+	publicKeyBytes := crypto.FromECDSAPub(publicKey)
+
+	return &SignedReceipt{
+		Receipt:         receipt,
+		Signature:       "0x" + hex.EncodeToString(signature),
+		ServerPublicKey: "0x" + hex.EncodeToString(publicKeyBytes),
+	}, nil
+}

--- a/gateway/receipt.go
+++ b/gateway/receipt.go
@@ -12,14 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-// ReceiptStore defines the interface for receipt storage implementations
-// This allows for easy swapping between in-memory, Redis, PostgreSQL, etc.
-type ReceiptStore interface {
-	Store(receipt *SignedReceipt, ttl time.Duration) error
-	Get(id string) (*SignedReceipt, error)
-	Delete(id string) error
-}
-
 // Receipt represents a cryptographic payment receipt
 type Receipt struct {
 	ID        string          `json:"id"`
@@ -35,7 +27,7 @@ type PaymentDetails struct {
 	Recipient string `json:"recipient"`
 	Amount    string `json:"amount"`
 	Token     string `json:"token"`
-	ChainID   int    `json:"chain_id"`
+	ChainID   int    `json:"chainId"`
 	Nonce     string `json:"nonce"`
 }
 
@@ -101,7 +93,7 @@ func hashData(data []byte) string {
 
 // signReceipt signs a receipt using the server's private key
 // NOTE: Go's json.Marshal is deterministic for structs - fields are always
-// serialized in declaration order (the order they appear in the struct definition).
+// serialized in alphabetical order by their JSON tag names.
 // This ensures consistent signatures. Non-determinism only affects map types.
 func signReceipt(receipt Receipt) (*SignedReceipt, error) {
 	// Get server's private key
@@ -111,7 +103,7 @@ func signReceipt(receipt Receipt) (*SignedReceipt, error) {
 	}
 
 	// Serialize receipt deterministically
-	// For structs, json.Marshal always outputs fields in declaration order
+	// For structs, json.Marshal always outputs fields in alphabetical order by JSON tag
 	receiptBytes, err := json.Marshal(receipt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal receipt: %w", err)

--- a/gateway/receipt_test.go
+++ b/gateway/receipt_test.go
@@ -151,7 +151,9 @@ func TestReceiptJSONSerialization(t *testing.T) {
 
 	// Verify all fields are present
 	var decoded map[string]interface{}
-	json.Unmarshal(json1, &decoded)
+	if err := json.Unmarshal(json1, &decoded); err != nil {
+		t.Fatalf("Failed to unmarshal JSON for field verification: %v", err)
+	}
 
 	requiredFields := []string{"id", "version", "timestamp", "payment", "service"}
 	for _, field := range requiredFields {
@@ -234,7 +236,8 @@ func hashHex(data []byte) string {
 func TestVerifyReceiptSignature(t *testing.T) {
 	// This test verifies that signature verification works correctly
 	// Skip if private key not available
-	if serverPrivateKey == nil {
+	privateKey, err := getServerPrivateKey()
+	if err != nil || privateKey == nil {
 		t.Skip("Skipping verification test: SERVER_WALLET_PRIVATE_KEY not set")
 	}
 
@@ -293,7 +296,8 @@ func TestReceiptFullFlowIntegration(t *testing.T) {
 	// 5. Verify expiration
 
 	// Skip if private key not available
-	if serverPrivateKey == nil {
+	privateKey, err := getServerPrivateKey()
+	if err != nil || privateKey == nil {
 		t.Skip("Skipping integration test: SERVER_WALLET_PRIVATE_KEY not set")
 	}
 

--- a/gateway/receipt_test.go
+++ b/gateway/receipt_test.go
@@ -278,6 +278,7 @@ func TestVerifyReceiptSignature(t *testing.T) {
 	serverPubBytes := crypto.FromECDSAPub(&serverPrivateKey.PublicKey)
 
 	// Verify signature without recovery ID (remove last byte which is the recovery ID)
+	// SECURITY: crypto.VerifySignature uses constant-time comparison to prevent timing attacks
 	if !crypto.VerifySignature(serverPubBytes, hash.Bytes(), sigBytes[:64]) {
 		t.Error("Signature verification failed")
 	}

--- a/gateway/receipt_test.go
+++ b/gateway/receipt_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestGenerateReceiptID(t *testing.T) {
+	// Generate multiple IDs and check format
+	ids := make(map[string]bool)
+	
+	for i := 0; i < 100; i++ {
+		id := generateReceiptID()
+		
+		// Check format
+		if !strings.HasPrefix(id,  "rcpt_") {
+			t.Errorf("Receipt ID should start with 'rcpt_', got: %s", id)
+		}
+		
+		// Check length (rcpt_ + 12 hex chars = 17 total)
+		if len(id) != 17 {
+			t.Errorf("Receipt ID should be 17 characters, got %d: %s", len(id), id)
+		}
+		
+		// Check uniqueness
+		if ids[id] {
+			t.Errorf("Duplicate receipt ID generated: %s", id)
+		}
+		ids[id] = true
+	}
+}
+
+func TestHashData(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected string
+	}{
+		{
+			name:     "Empty data",
+			data:     []byte{},
+			expected: "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:     "Simple text",
+			data:     []byte("test"),
+			expected: "sha256:" + hashHex([]byte("test")),
+		},
+		{
+			name:     "JSON data",
+			data:     []byte(`{"key":"value"}`),
+			expected: "sha256:" + hashHex([]byte(`{"key":"value"}`)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hashData(tt.data)
+			if result != tt.expected {
+				t.Errorf("hashData() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSignReceipt(t *testing.T) {
+	// Create a test receipt
+	receipt := Receipt{
+		ID:        "rcpt_test123456",
+		Version:   "1.0",
+		Timestamp: time.Now().UTC(),
+		Payment: PaymentDetails{
+			Payer:     "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE21",
+			Recipient: "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219",
+			Amount:    "0.001",
+			Token:     "USDC",
+			ChainID:   8453,
+			Nonce:     "test-nonce-123",
+		},
+		Service: ServiceDetails{
+			Endpoint:     "/api/ai/summarize",
+			RequestHash:  "sha256:abc123",
+			ResponseHash: "sha256:def456",
+		},
+	}
+
+	// This test requires SERVER_WALLET_PRIVATE_KEY to be set
+	// Skip if not available
+	if serverPrivateKey == nil {
+		t.Skip("Skipping signature test: SERVER_WALLET_PRIVATE_KEY not set")
+	}
+
+	signedReceipt, err := signReceipt(receipt)
+	if err != nil {
+		t.Fatalf("Failed to sign receipt: %v", err)
+	}
+
+	// Verify signature format
+	if !strings.HasPrefix(signedReceipt.Signature, "0x") {
+		t.Error("Signature should start with '0x'")
+	}
+
+	// Verify server public key format
+	if !strings.HasPrefix(signedReceipt.ServerPublicKey, "0x") {
+		t.Error("ServerPublicKey should start with '0x'")
+	}
+
+	// Verify receipt is intact
+	if signedReceipt.Receipt.ID != receipt.ID {
+		t.Error("Receipt ID mismatch after signing")
+	}
+}
+
+func TestReceiptJSONSerialization(t *testing.T) {
+	receipt := Receipt{
+		ID:        "rcpt_abc123def456",
+		Version:   "1.0",
+		Timestamp: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Payment: PaymentDetails{
+			Payer:     "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE21",
+			Recipient: "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219",
+			Amount:    "0.001",
+			Token:     "USDC",
+			ChainID:   8453,
+			Nonce:     "test-nonce",
+		},
+		Service: ServiceDetails{
+			Endpoint:     "/api/ai/summarize",
+			RequestHash:  "sha256:request",
+			ResponseHash: "sha256:response",
+		},
+	}
+
+	// Serialize twice to check determinism
+	json1, err1 := json.Marshal(receipt)
+	json2, err2 := json.Marshal(receipt)
+
+	if err1 != nil || err2 != nil {
+		t.Fatalf("JSON marshaling failed: %v, %v", err1, err2)
+	}
+
+	if string(json1) != string(json2) {
+		t.Error("JSON serialization is not deterministic")
+	}
+
+	// Verify all fields are present
+	var decoded map[string]interface{}
+	json.Unmarshal(json1, &decoded)
+
+	requiredFields := []string{"id", "version", "timestamp", "payment", "service"}
+	for _, field := range requiredFields {
+		if _, exists := decoded[field]; !exists {
+			t.Errorf("Missing field in JSON: %s", field)
+		}
+	}
+}
+
+func TestStoreAndRetrieveReceipt(t *testing.T) {
+	signedReceipt := &SignedReceipt{
+		Receipt: Receipt{
+			ID:        generateReceiptID(),
+			Version:   "1.0",
+			Timestamp: time.Now().UTC(),
+			Payment: PaymentDetails{
+				Payer:     "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE21",
+				Recipient: "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219",
+				Amount:    "0.001",
+				Token:     "USDC",
+				ChainID:   8453,
+				Nonce:     "test-nonce",
+			},
+			Service: ServiceDetails{
+				Endpoint:     "/api/ai/summarize",
+				RequestHash:  "sha256:test",
+				ResponseHash: "sha256:response",
+			},
+		},
+		Signature:       "0x1234567890abcdef",
+		ServerPublicKey: "0xabcdef1234567890",
+	}
+
+	// Store receipt
+	storeReceipt(signedReceipt, 24*time.Hour)
+
+	// Retrieve receipt
+	retrieved, exists := getReceipt(signedReceipt.Receipt.ID)
+	if !exists {
+		t.Fatal("Receipt not found after storing")
+	}
+
+	if retrieved.Receipt.ID != signedReceipt.Receipt.ID {
+		t.Error("Retrieved receipt ID doesn't match stored receipt")
+	}
+
+	if retrieved.Signature != signedReceipt.Signature {
+		t.Error("Retrieved receipt signature doesn't match")
+	}
+}
+
+func TestReceiptNotFound(t *testing.T) {
+	_, exists := getReceipt("rcpt_nonexistent")
+	if exists {
+		t.Error("Non-existent receipt should not be found")
+	}
+}
+
+func TestHashDataConsistency(t *testing.T) {
+	data := []byte("consistent test data")
+
+	// Hash multiple times
+	hash1 := hashData(data)
+	hash2 := hashData(data)
+	hash3 := hashData(data)
+
+	if hash1 != hash2 || hash2 != hash3 {
+		t.Error("hashData should produce consistent results")
+	}
+}
+
+// Helper function for testing
+func hashHex(data []byte) string {
+	hash := sha256.Sum256(data)
+	return hex.EncodeToString(hash[:])
+}
+
+func TestVerifyReceiptSignature(t *testing.T) {
+	// This test verifies that signature verification works correctly
+	// Skip if private key not available
+	if serverPrivateKey == nil {
+		t.Skip("Skipping verification test: SERVER_WALLET_PRIVATE_KEY not set")
+	}
+
+	receipt := Receipt{
+		ID:        generateReceiptID(),
+		Version:   "1.0",
+		Timestamp: time.Now().UTC(),
+		Payment: PaymentDetails{
+			Payer:     "0x742d35Cc6634C0532925a3b844Bc9e7595f8fE21",
+			Recipient: "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219",
+			Amount:    "0.001",
+			Token:     "USDC",
+			ChainID:   8453,
+			Nonce:     "test-nonce-verification",
+		},
+		Service: ServiceDetails{
+			Endpoint:     "/api/ai/summarize",
+			RequestHash:  "sha256:testrequest",
+			ResponseHash: "sha256:testresponse",
+		},
+	}
+
+	signedReceipt, err := signReceipt(receipt)
+	if err != nil {
+		t.Fatalf("Failed to sign receipt: %v", err)
+	}
+
+	// Manually verify the signature
+	receiptBytes, _ := json.Marshal(signedReceipt.Receipt)
+	hash := crypto.Keccak256Hash(receiptBytes)
+
+	// Remove "0x" prefix from signature
+	sigHex := signedReceipt.Signature[2:]
+	sigBytes, _ := hex.DecodeString(sigHex)
+
+	// Recover public key
+	pubKey, err := crypto.SigToPub(hash.Bytes(), sigBytes)
+	if err != nil {
+		t.Fatalf("Failed to recover public key: %v", err)
+	}
+
+	// Compare with server's public key
+	serverPubBytes := crypto.FromECDSAPub(&serverPrivateKey.PublicKey)
+	recoveredPubBytes := crypto.FromECDSAPub(pubKey)
+
+	if hex.EncodeToString(serverPubBytes) != hex.EncodeToString(recoveredPubBytes) {
+		t.Error("Recovered public key doesn't match server's public key")
+	}
+}

--- a/gateway/receipt_test.go
+++ b/gateway/receipt_test.go
@@ -16,7 +16,10 @@ func TestGenerateReceiptID(t *testing.T) {
 	ids := make(map[string]bool)
 	
 	for i := 0; i < 100; i++ {
-		id := generateReceiptID()
+		id, err := generateReceiptID()
+		if err != nil {
+			t.Fatalf("generateReceiptID() failed: %v", err)
+		}
 		
 		// Check format
 		if !strings.HasPrefix(id,  "rcpt_") {
@@ -164,9 +167,14 @@ func TestReceiptJSONSerialization(t *testing.T) {
 }
 
 func TestStoreAndRetrieveReceipt(t *testing.T) {
+	receiptID, err := generateReceiptID()
+	if err != nil {
+		t.Fatalf("generateReceiptID() failed: %v", err)
+	}
+
 	signedReceipt := &SignedReceipt{
 		Receipt: Receipt{
-			ID:        generateReceiptID(),
+			ID:        receiptID,
 			Version:   "1.0",
 			Timestamp: time.Now().UTC(),
 			Payment: PaymentDetails{
@@ -241,8 +249,13 @@ func TestVerifyReceiptSignature(t *testing.T) {
 		t.Skip("Skipping verification test: SERVER_WALLET_PRIVATE_KEY not set")
 	}
 
+	receiptID, err := generateReceiptID()
+	if err != nil {
+		t.Fatalf("generateReceiptID() failed: %v", err)
+	}
+
 	receipt := Receipt{
-		ID:        generateReceiptID(),
+		ID:        receiptID,
 		Version:   "1.0",
 		Timestamp: time.Now().UTC(),
 		Payment: PaymentDetails{

--- a/web/src/lib/verify-receipt.ts
+++ b/web/src/lib/verify-receipt.ts
@@ -1,0 +1,146 @@
+/**
+ * Receipt Verification Library for MicroAI-Paygate
+ * 
+ * Verifies cryptographic receipts using ECDSA signatures and Keccak256 hashing.
+ * Compatible with Ethereum wallet signatures.
+ * 
+ * @module verify-receipt
+ */
+
+import { ethers } from 'ethers';
+
+// Type definitions matching backend Go structs
+
+export interface PaymentDetails {
+  payer: string;
+  recipient: string;
+  amount: string;
+  token: string;
+  chainId: number;
+  nonce: string;
+}
+
+export interface ServiceDetails {
+  endpoint: string;
+  request_hash: string;
+  response_hash: string;
+}
+
+export interface Receipt {
+  id: string;
+  version: string;
+  timestamp: string;
+  payment: PaymentDetails;
+  service: ServiceDetails;
+}
+
+export interface SignedReceipt {
+  receipt: Receipt;
+  signature: string;
+  server_public_key: string;
+}
+
+/**
+ * Verifies a cryptographic receipt signature
+ * 
+ * @param signedReceipt - The signed receipt from the API response
+ * @returns Promise<boolean> - true if signature is valid
+ * 
+ * @example
+ * ```typescript
+ * const response = await fetch('/api/ai/summarize', { ...headers... });
+ * const data = await response.json();
+ * const isValid = await verifyReceipt(data.receipt);
+ * console.log(`Receipt valid: ${isValid}`);
+ * ```
+ */
+export async function verifyReceipt(signedReceipt: SignedReceipt): Promise<boolean> {
+  try {
+    // Validate structure
+    if (!signedReceipt?.receipt || !signedReceipt.signature || !signedReceipt.server_public_key) {
+      console.error('Invalid receipt structure');
+      return false;
+    }
+
+    // Serialize receipt deterministically (alphabetical by JSON tag, same as Go)
+    const receiptJSON = JSON.stringify(signedReceipt.receipt);
+    
+    // Hash using Keccak256 (Ethereum-compatible)
+    const messageHash = ethers.keccak256(ethers.toUtf8Bytes(receiptJSON));
+
+    // Recover signer address from signature
+    const recoveredAddress = ethers.recoverAddress(messageHash, signedReceipt.signature);
+
+    // Compute address from server's public key
+    const serverAddress = ethers.computeAddress(signedReceipt.server_public_key);
+
+    // Compare addresses (case-insensitive)
+    return recoveredAddress.toLowerCase() === serverAddress.toLowerCase();
+  } catch (error) {
+    console.error('Receipt verification failed:', error);
+    return false;
+  }
+}
+
+/**
+ * Validates receipt format without verifying signature
+ * 
+ * @param signedReceipt - The receipt to validate
+ * @returns boolean - true if format is valid
+ */
+export function validateReceiptFormat(signedReceipt: SignedReceipt): boolean {
+  if (!signedReceipt?.receipt) return false;
+  
+  const r = signedReceipt.receipt;
+  
+  return !!(
+    r.id?.startsWith('rcpt_') &&
+    r.version &&
+    r.timestamp &&
+    r.payment?.payer &&
+    r.payment?.recipient &&
+    r.payment?.amount &&
+    r.payment?.token &&
+    r.payment?.nonce &&
+    r.service?.endpoint &&
+    r.service?.request_hash &&
+    r.service?.response_hash &&
+    signedReceipt.signature?.startsWith('0x') &&
+    signedReceipt.server_public_key?.startsWith('0x')
+  );
+}
+
+/**
+ * Fetches a receipt by ID from the gateway
+ * 
+ * @param receiptId - Receipt ID (e.g., "rcpt_abc123")
+ * @param gatewayUrl - Gateway base URL (default: http://localhost:3000)
+ * @returns Promise<SignedReceipt | null>
+ */
+export async function fetchReceipt(
+  receiptId: string,
+  gatewayUrl: string = 'http://localhost:3000'
+): Promise<SignedReceipt | null> {
+  try {
+    const response = await fetch(`${gatewayUrl}/api/receipts/${receiptId}`);
+    
+    if (response.status === 404) {
+      return null;
+    }
+    
+    if (!response.ok) {
+      throw new Error(`Failed to fetch receipt: ${response.statusText}`);
+    }
+    
+    const data = await response.json();
+    
+    return {
+      receipt: data.receipt,
+      signature: data.signature,
+      server_public_key: data.server_public_key,
+    };
+  } catch (error) {
+    console.error('Error fetching receipt:', error);
+    return null;
+  }
+}


### PR DESCRIPTION
<h2>Greptile Overview</h2>
closes #16 
### Greptile Summary

This PR implements cryptographic payment receipts for the MicroAI-Paygate system, providing tamper-proof proof-of-payment for every successful API request.

**Major changes:**
- Added receipt generation with ECDSA signatures (Keccak256) in `gateway/receipt.go`
- Integrated receipt creation into the payment flow after AI responses
- Added `GET /api/receipts/:id` endpoint for receipt lookup
- Implemented in-memory receipt storage with TTL-based cleanup
- Added TypeScript client library for receipt verification in `web/src/lib/verify-receipt.ts`
- Comprehensive test coverage (10 tests including integration tests)

**Issues found:**
- **JSON serialization mismatch**: The TypeScript verification library uses `JSON.stringify` which doesn't guarantee field order matches Go's `json.Marshal`. This could cause signature verification to fail if field orders diverge.
- **Misleading comment**: The comment in `receipt.go` claims `json.Marshal` serializes "alphabetically by JSON tag", but Go actually serializes in struct field definition order.
- **Request body reading**: Body is read twice (parsing + hashing), which could allow large invalid payloads to consume memory before validation.
- **Key validation**: Accepts keys as short as 16 bytes with left-padding, which may mask truncated/invalid configurations.

**Positive aspects:**
- Well-structured architecture with `ReceiptStore` interface for future extensibility
- Comprehensive test suite covering edge cases and TTL behavior
- Good security practices (constant-time operations, SHA-256 hashing, proper random ID generation)
- Thread-safe storage with proper mutex usage
- Proper cleanup goroutine with graceful shutdown handling
- 10MB body size limit to prevent DoS attacks

### Confidence Score: 4/5

- This PR is generally safe to merge with minor issues that should be monitored in testing
- Score reflects a solid implementation with good security practices and comprehensive tests. The main concern is the potential JSON serialization mismatch between Go and TypeScript which could affect receipt verification, though this is mitigated by Go's deterministic struct field ordering. The code includes proper DoS protections, thread-safe storage, and thorough test coverage. Minor issues like misleading comments and weak key validation are non-critical.
- Monitor `web/src/lib/verify-receipt.ts` in testing to ensure JSON serialization order matches Go's behavior for signature verification

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| web/src/lib/verify-receipt.ts | 4/5 | TypeScript receipt verification library using ethers.js for signature recovery. Implementation looks correct with proper recovery ID adjustment (v+27). |
| gateway/receipt.go | 4/5 | Receipt generation and signing implementation using Keccak256 and ECDSA. Clean code with good security practices and proper error handling. |
| gateway/receipt_test.go | 5/5 | Comprehensive test suite with 10 tests covering unit tests, integration tests, and TTL behavior. Well-structured and thorough. |
| gateway/main.go | 4/5 | Receipt integration into handleSummarize with proper storage, cleanup goroutine, and GET endpoint. Includes body size limits and proper error handling. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant G as Gateway
    participant V as Verifier
    participant AI as OpenRouter
    participant S as Receipt Store

    Note over C,G: Payment verification (existing flow)
    C->>G: POST /api/ai/summarize + X-402-Signature
    G->>V: Verify signature
    V-->>G: Valid ✓ + recovered_address
    
    Note over G,AI: AI request processing
    G->>AI: Forward summarize request
    AI-->>G: AI response

    Note over G,S: NEW: Receipt generation & storage
    G->>G: Hash request body (SHA-256)
    G->>G: Hash response body (SHA-256)
    G->>G: Create Receipt struct
    G->>G: Sign with server private key (ECDSA)
    G->>S: Store receipt with 24h TTL
    S-->>G: Stored ✓
    
    Note over G,C: Response with receipt
    G-->>C: 200 OK + result + receipt (JSON & header)
    
    Note over C: Client-side verification
    C->>C: Verify receipt signature
    C->>C: Store receipt locally
    
    Note over C,G: Receipt lookup (new endpoint)
    C->>G: GET /api/receipts/rcpt_abc123
    G->>S: Retrieve by ID
    S-->>G: Receipt data or 404
    G-->>C: Receipt with signature + status
```