### PR TITLE
fix: use go run . and update env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,9 @@ NODE_ENV=development
 
 # AI Service
 OPENROUTER_API_KEY=your_openrouter_key_here
-OPENROUTER_MODEL=z-ai/glm-4.5-air:free
+# Any OpenRouter text model - see https://openrouter.ai/models for options
+# Free models: google/gemma-3-1b-it:free, meta-llama/llama-3.2-1b-instruct:free
+OPENROUTER_MODEL=google/gemma-3-1b-it:free
 # Optional: override the OpenRouter endpoint (used in tests)
 # OPENROUTER_URL=http://127.0.0.1:8080/api/v1/chat/completions
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -441,6 +441,7 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 
 	choices, ok := result["choices"].([]interface{})
 	if !ok || len(choices) == 0 {
+		log.Printf("OpenRouter response: %+v", result)
 		return "", fmt.Errorf("invalid response from AI provider: no choices")
 	}
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "bun run --watch src/index.ts",
     "agent": "bun run agent/bot.ts",
     "dev:all": "concurrently \"bun run dev\" \"sleep 2 && bun run agent\"",
-    "stack": "concurrently -n \"VERIFIER,GATEWAY,WEB\" -c \"red,cyan,green\" \"cd verifier && cargo run\" \"cd gateway && go run main.go\" \"cd web && bun run dev\"",
+    "stack": "concurrently -n \"VERIFIER,GATEWAY,WEB\" -c \"red,cyan,green\" \"cd verifier && cargo run\" \"cd gateway && go run .\" \"cd web && bun run dev\"",
     "test:unit": "cd gateway && go test ./... && cd ../verifier && cargo test",
     "test:go": "cd gateway && go test ./...",
     "test:rust": "cd verifier && cargo test",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default AI model used for processing requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR makes three small but meaningful improvements to the project:

- **Command standardization**: Changed `go run main.go` to `go run .` in the stack script, following Go best practices for running packages
- **Better debugging**: Added logging of the full OpenRouter API response when invalid responses are received, making it easier to troubleshoot API issues
- **Improved documentation**: Updated `.env.example` with the new default model (`google/gemma-3-1b-it:free`) and added helpful comments listing free model options

All changes are low-risk configuration and developer experience improvements. No functional logic changes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- All changes are non-functional improvements: updating environment documentation, following Go best practices with `go run .`, and adding helpful debug logging. No logic changes, no security concerns, and no breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .env.example | Updated default OPENROUTER_MODEL to `google/gemma-3-1b-it:free` and added helpful documentation comments for model selection |
| gateway/main.go | Added debug logging to help troubleshoot invalid OpenRouter API responses |
| package.json | Changed Go command from `go run main.go` to `go run .` following Go best practices |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as npm stack script
    participant Gateway as Gateway (Go)
    participant OpenRouter as OpenRouter API
    
    Dev->>NPM: npm run stack
    NPM->>Gateway: go run . (was: go run main.go)
    Note over Gateway: Loads .env config
    Note over Gateway: OPENROUTER_MODEL=google/gemma-3-1b-it:free
    
    Gateway->>OpenRouter: POST /api/v1/chat/completions
    alt Valid Response
        OpenRouter-->>Gateway: {choices: [...]}
        Gateway->>Gateway: Parse response
    else Invalid Response
        OpenRouter-->>Gateway: Invalid/malformed response
        Gateway->>Gateway: log.Printf("OpenRouter response: %+v", result)
        Gateway-->>Dev: Error: invalid response from AI provider
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->