### PR TITLE
refactor(docs): extract Swagger UI into template with configurable

### DIFF
--- a/gateway/docs_test.go
+++ b/gateway/docs_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestDocs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	r.GET("/docs", func(c *gin.Context) {
+		data := struct{ Version string }{Version: "5.11.0"}
+		if err := swaggerTmpl.Execute(c.Writer, data); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	req, _ := http.NewRequest("GET", "/docs", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	if !strings.Contains(w.Body.String(), "swagger-ui") {
+		t.Fatal("swagger ui not rendered")
+	}
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -13,7 +13,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+ 
 	"io"
+
+	"html/template"
+
 	"log"
 	"net/http"
 	"os"
@@ -52,6 +56,7 @@ type SummarizeRequest struct {
 	Text string `json:"text"`
 }
 
+
 func validateConfig() error {
 	required := []string{
 		"OPENROUTER_API_KEY",
@@ -67,6 +72,22 @@ func validateConfig() error {
 	}
 	return nil
 }
+
+var swaggerTmpl *template.Template
+
+func init() {
+	swaggerTmpl = template.Must(
+		template.ParseFiles("templates/swagger.html"),
+	)
+}
+func getSwaggerUIVersion() string {
+	if v := os.Getenv("SWAGGER_UI_VERSION"); v != "" {
+		return v
+	}
+	return "5.11.0"
+}
+
+
 func main() {
 	// Try loading .env from current directory first, then fallback to parent
 	err := godotenv.Load(".env")
@@ -120,25 +141,16 @@ func main() {
 
 	r.GET("/docs", func(c *gin.Context) {
 		c.Header("Content-Type", "text/html")
-		c.String(200, `
-<!DOCTYPE html>
-<html>
-<head>
-  <title>MicroAI Paygate Docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
-  <script>
-    SwaggerUIBundle({
-      url: '/openapi.yaml',
-      dom_id: '#swagger-ui'
-    });
-  </script>
-</body>
-</html>
-`)
+
+		data := struct {
+			Version string
+		}{
+			Version: getSwaggerUIVersion(),
+		}
+
+		if err := swaggerTmpl.Execute(c.Writer, data); err != nil {
+			c.String(500, "failed to render swagger ui")
+		}
 	})
 
 	r.Use(cors.New(cors.Config{

--- a/gateway/templates/swagger.html
+++ b/gateway/templates/swagger.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>MicroAI Paygate API Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@{{.Version}}/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+
+  <script src="https://unpkg.com/swagger-ui-dist@{{.Version}}/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: '/openapi.yaml',
+      dom_id: '#swagger-ui'
+    });
+  </script>
+</body>
+</html>
+
+
+


### PR DESCRIPTION
This PR removes hardcoded Swagger UI HTML from Go code and moves it
to an external HTML template.

Changes:
- Extract Swagger UI into gateway/templates/swagger.html
- Make Swagger UI version configurable via SWAGGER_UI_VERSION
- Default version remains 5.11.0
- Add test coverage for /docs endpoint

This improves maintainability and makes Swagger UI upgrades easier
without recompiling the gateway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Swagger UI template-based rendering for the /docs endpoint, replacing hard-coded static HTML with dynamic template support.
  * Added configurable Swagger UI version through environment variables with fallback to default values.

* **Tests**
  * Added new test case for the Docs endpoint, verifying HTTP 200 response and correct Swagger UI component rendering in the response.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Extracts Swagger UI HTML from hardcoded Go code into an external template with configurable version via `SWAGGER_UI_VERSION` environment variable. Adds test coverage for the `/docs` endpoint.

- **Critical bug**: The `Dockerfile` doesn't copy the `templates/` directory, so Docker deployments will crash on startup when `template.Must()` fails to find `templates/swagger.html`
- Uses `html/template` for proper XSS protection on the version variable
- Test coverage added but only validates local execution, not Docker deployment

<h3>Confidence Score: 2/5</h3>


- This PR will break Docker deployments due to missing template directory in the container image.
- Score of 2 reflects a critical deployment bug - the Dockerfile doesn't copy the templates directory, causing the gateway to panic on startup in Docker. The code is otherwise well-structured, using html/template for XSS safety and adding tests.
- gateway/Dockerfile needs to be updated to copy the templates directory

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/main.go | Extracts Swagger UI into template with configurable version. Critical issue: template uses relative path that won't resolve in Docker deployment since Dockerfile doesn't copy the templates directory. |
| gateway/templates/swagger.html | New HTML template for Swagger UI. Uses html/template which provides auto-escaping for the Version variable. |
| gateway/docs_test.go | New test for /docs endpoint. Tests work locally but don't catch the Docker deployment issue since tests run from gateway directory where relative path works. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Gateway
    participant Template
    participant Swagger CDN

    Note over Gateway: init() loads templates/swagger.html
    User->>Gateway: GET /docs
    Gateway->>Template: Execute with {Version}
    Template-->>Gateway: Rendered HTML
    Gateway-->>User: HTML response
    User->>Swagger CDN: Load swagger-ui-dist@{Version}
    Swagger CDN-->>User: JS/CSS assets
    User->>Gateway: GET /openapi.yaml
    Gateway-->>User: OpenAPI spec
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->