### PR TITLE
feat: add health check and signature verification endpoints with response structure

### DIFF
--- a/verifier/README.md
+++ b/verifier/README.md
@@ -55,7 +55,7 @@ curl http://localhost:3002/health
 {
   "status": "healthy",
   "service": "verifier",
-  "version": "0.1.0"
+  "version": "<cargo pkg version>"
 }
 ```
 

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -42,10 +42,30 @@ Current implementation has no required env vars. It uses hardcoded EIP-712 domai
 
 If you change domain parameters in the gateway/frontend, update them here to stay in sync.
 
-## Health and Verification
+## API Endpoints
 
-- Health: `curl http://localhost:3002/health`
-- Verify: `curl -X POST http://localhost:3002/verify -H "Content-Type: application/json" -d '{"context":{...},"signature":"0x..."}'`
+### Health Check
+
+```bash
+curl http://localhost:3002/health
+```
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "service": "verifier",
+  "version": "0.1.0"
+}
+```
+
+The health endpoint returns the service status, name, and current version from Cargo.toml. Use this endpoint to verify the verifier is running and to detect if the service is down.
+
+### Signature Verification
+
+```bash
+curl -X POST http://localhost:3002/verify -H "Content-Type: application/json" -d '{"context":{...},"signature":"0x..."}'
+```
 
 ## Testing
 

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -24,8 +24,19 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn health() -> &'static str {
-    "Rust Verifier OK"
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    service: &'static str,
+    version: &'static str,
+}
+
+async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "healthy",
+        service: "verifier",
+        version: env!("CARGO_PKG_VERSION"),
+    })
 }
 
 #[derive(Deserialize, Debug)]
@@ -175,6 +186,15 @@ mod tests {
     use super::*;
     use ethers::signers::{LocalWallet, Signer};
     use ethers::types::transaction::eip712::TypedData;
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let Json(response) = health().await;
+        
+        assert_eq!(response.status, "healthy");
+        assert_eq!(response.service, "verifier");
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+    }
 
     #[tokio::test]
     async fn test_verify_signature_valid() {

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -31,18 +31,23 @@ struct HealthResponse {
     version: &'static str,
 }
 
-async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
-    // Extract ID
+fn correlation_id_headers(headers: &HeaderMap) -> (String, HeaderMap) {
+    // Extract correlation ID
     let correlation_id = headers
         .get("X-Correlation-ID")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("unknown");
 
-    // Prepare response header
     let mut res_headers = HeaderMap::new();
     if let Ok(header_value) = correlation_id.parse() {
         res_headers.insert("X-Correlation-ID", header_value);
     }
+
+    (correlation_id.to_string(), res_headers)
+}
+
+async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
+    let (_correlation_id, res_headers) = correlation_id_headers(&headers);
 
     (
         res_headers,
@@ -81,17 +86,7 @@ async fn verify_signature(
     headers: HeaderMap,
     Json(payload): Json<VerifyRequest>,
 ) -> (StatusCode, HeaderMap, Json<VerifyResponse>) {
-    // Extract ID
-    let correlation_id = headers
-        .get("X-Correlation-ID")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("unknown");
-
-    // Prepare response header
-    let mut res_headers = HeaderMap::new();
-    if let Ok(header_value) = correlation_id.parse() {
-        res_headers.insert("X-Correlation-ID", header_value);
-    }
+    let (correlation_id, res_headers) = correlation_id_headers(&headers);
 
     println!(
         "[CorrelationID: {}] Received verification request for nonce: {}",

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -31,12 +31,27 @@ struct HealthResponse {
     version: &'static str,
 }
 
-async fn health() -> Json<HealthResponse> {
-    Json(HealthResponse {
-        status: "healthy",
-        service: "verifier",
-        version: env!("CARGO_PKG_VERSION"),
-    })
+async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
+    // Extract ID
+    let correlation_id = headers
+        .get("X-Correlation-ID")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+
+    // Prepare response header
+    let mut res_headers = HeaderMap::new();
+    if let Ok(header_value) = correlation_id.parse() {
+        res_headers.insert("X-Correlation-ID", header_value);
+    }
+
+    (
+        res_headers,
+        Json(HealthResponse {
+            status: "healthy",
+            service: "verifier",
+            version: env!("CARGO_PKG_VERSION"),
+        }),
+    )
 }
 
 #[derive(Deserialize, Debug)]
@@ -189,11 +204,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_health_endpoint() {
-        let Json(response) = health().await;
-        
+        let (_headers, Json(response)) = health(HeaderMap::new()).await;
+
         assert_eq!(response.status, "healthy");
         assert_eq!(response.service, "verifier");
         assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint_correlation_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert("X-Correlation-ID", "health-check-id".parse().unwrap());
+
+        let (res_headers, Json(response)) = health(headers).await;
+
+        assert_eq!(response.status, "healthy");
+
+        let response_id = res_headers.get("X-Correlation-ID");
+        assert!(response_id.is_some());
+        assert_eq!(response_id.unwrap().to_str().unwrap(), "health-check-id");
     }
 
     #[tokio::test]

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Json,
-    http::{HeaderMap, StatusCode}, // VIBE FIX: Added HeaderMap to read headers
+    http::{HeaderMap, StatusCode},
     routing::{get, post},
     Router,
 };


### PR DESCRIPTION
## Summary
This pull request improves the health check endpoint in the verifier service by making its response more informative and updating the documentation accordingly. It also adds a new test to ensure the health endpoint works as expected.

## Related Issue 
Closes #44 

## Changes 
**API improvements:**

* The `/health` endpoint now returns a structured JSON response with service status, name, and version, instead of a plain string. (`verifier/src/main.rs`)
* The `README.md` is updated to document the new `/health` endpoint response format and provide clearer API usage instructions. (`verifier/README.md`)

**Testing:**

* A new test is added to verify that the `/health` endpoint returns the expected JSON response, including the correct version from Cargo.toml. (`verifier/src/main.rs`)

## Results
<img width="984" height="263" alt="image" src="https://github.com/user-attachments/assets/d4f61321-5550-44c6-8a2f-ed588a2930eb" />

## Review
@AnkanMisra



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint now returns a structured JSON payload with status, service name, and version.
  * Responses echo a request correlation ID when provided for improved traceability.

* **Documentation**
  * README updated with API endpoint examples, curl commands, and sample responses.

* **Tests**
  * Added tests for health response fields and correlation ID behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully improves the health check endpoint by returning structured JSON with service status, name, and version. It also addresses the previously identified issue by adding `X-Correlation-ID` header propagation to the health endpoint for consistent distributed tracing.

**Key improvements:**
- Health endpoint now returns structured JSON: `{status, service, version}` instead of plain text
- `X-Correlation-ID` header support added to health endpoint for consistent tracing across the stack
- Comprehensive test coverage added including correlation ID propagation tests
- Documentation updated with clear API usage examples and response formats

**Minor issue:**
- Comment on line 35 could be more descriptive ("Extract ID" → "Extract correlation ID")

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - the changes are well-tested and address the previous review feedback
- Score reflects solid implementation with comprehensive tests and proper correlation ID handling. The only minor issue is a comment that could be more descriptive, which doesn't affect functionality. The PR successfully addresses the previous review concern about correlation ID propagation in the health endpoint.
- No files require special attention - both changes are straightforward and well-tested

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| verifier/README.md | Improved documentation with structured API endpoint examples and clearer health check response format |
| verifier/src/main.rs | Added structured health response with correlation ID support and comprehensive tests, but has minor issues with comment clarity |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Verifier
    
    Note over Client,Verifier: Health Check Flow
    Client->>Verifier: GET /health<br/>(X-Correlation-ID: optional)
    Verifier->>Verifier: Extract correlation ID from headers<br/>(or use "unknown")
    Verifier->>Verifier: Build HealthResponse struct<br/>(status, service, version)
    Verifier->>Client: 200 OK<br/>JSON response + X-Correlation-ID header
    
    Note over Client,Verifier: Signature Verification Flow
    Client->>Verifier: POST /verify<br/>(X-Correlation-ID: optional)<br/>Body: {context, signature}
    Verifier->>Verifier: Extract correlation ID from headers<br/>(or use "unknown")
    Verifier->>Verifier: Reconstruct EIP-712 TypedData<br/>(domain, types, message)
    Verifier->>Verifier: Parse signature string
    Verifier->>Verifier: Recover signer address using ECDSA
    alt Valid Signature
        Verifier->>Client: 200 OK<br/>{is_valid: true, recovered_address}<br/>+ X-Correlation-ID header
    else Invalid Signature
        Verifier->>Client: 200 OK<br/>{is_valid: false, error}<br/>+ X-Correlation-ID header
    else Parse Error
        Verifier->>Client: 400 Bad Request<br/>{is_valid: false, error}<br/>+ X-Correlation-ID header
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->