### PR TITLE
fix: comprehensive startup configuration validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ OPENROUTER_MODEL=google/gemma-3-1b-it:free
 # OPENROUTER_URL=http://127.0.0.1:8080/api/v1/chat/completions
 
 # Payment Configuration
-# Private key for the server wallet (recipient of payments)
+# Private key for the server wallet (recipient of payments) - REQUIRED
 SERVER_WALLET_PRIVATE_KEY=your_private_key_here
 # Recipient address (derived from private key, or set explicitly)
 RECIPIENT_ADDRESS=0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219 #dummy
@@ -68,6 +68,7 @@ HEALTH_CHECK_TIMEOUT_SECONDS=2
 
 # Redis Configuration (for Caching)
 # Use 'redis:6379' for docker-compose, 'localhost:6379' for local run
+# REQUIRED when CACHE_ENABLED=true
 REDIS_URL=redis:6379
 REDIS_PASSWORD=
 REDIS_DB=0

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -18,6 +18,18 @@ concurrency:
 jobs:
   go-tests:
     runs-on: ubuntu-latest
+    
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -31,3 +43,5 @@ jobs:
       - name: Run Go tests
         working-directory: gateway
         run: go test -v ./...
+        env:
+          REDIS_URL: localhost:6379

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -1,25 +1,198 @@
 package main
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
 
 func TestValidateConfig_MissingRequiredEnv(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "")
+	t.Setenv("CACHE_ENABLED", "false")
 
 	err := validateConfig()
 	if err == nil {
-		t.Fatalf("expected error when OPENROUTER_API_KEY is missing, got nil")
+		t.Fatalf("expected error when required env vars are missing, got nil")
+	}
+
+	expectedVars := []string{"OPENROUTER_API_KEY", "SERVER_WALLET_PRIVATE_KEY"}
+	errStr := err.Error()
+	for _, v := range expectedVars {
+		if !strings.Contains(errStr, v) {
+			t.Errorf("expected error to mention missing var %s, got: %v", v, err)
+		}
 	}
 }
 
 func TestValidateConfig_WithRequiredEnv(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("CACHE_ENABLED", "false")
 
 	err := validateConfig()
 	if err != nil {
-		t.Fatalf("expected no error when OPENROUTER_API_KEY is set, got: %v", err)
+		t.Fatalf("expected no error when required env vars are set, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CacheEnabledRequiresRedis(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("REDIS_URL", "")
+
+	err := validateConfig()
+	if err == nil {
+		t.Fatalf("expected error when CACHE_ENABLED=true but REDIS_URL is missing, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "REDIS_URL") {
+		t.Errorf("expected error to mention REDIS_URL, got: %v", err)
+	}
+}
+
+func TestValidateConfig_CacheEnabledWithValidRedis(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "test-key")
+	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("CACHE_ENABLED", "true")
+	t.Setenv("REDIS_URL", "localhost:6379")
+
+	err := validateConfig()
+	if err != nil {
+		t.Fatalf("expected no error when all required vars are set, got: %v", err)
+	}
+}
+
+func TestValidateServerPrivateKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid 32-byte key",
+			key:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			wantErr: false,
+		},
+		{
+			name:    "valid 31-byte key",
+			key:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcd",
+			wantErr: false,
+		},
+		{
+			name:    "valid key with 0x prefix",
+			key:     "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			wantErr: false,
+		},
+		{
+			name:    "empty key",
+			key:     "",
+			wantErr: true,
+			errMsg:  "SERVER_WALLET_PRIVATE_KEY not set",
+		},
+		{
+			name:    "too short key",
+			key:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789ab",
+			wantErr: true,
+			errMsg:  "private key too short",
+		},
+		{
+			name:    "too long key",
+			key:     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef00",
+			wantErr: true,
+			errMsg:  "private key must be at most 32 bytes",
+		},
+		{
+			name:    "invalid hex",
+			key:     "invalid-hex-string-not-valid-hex-chars-here-zzz",
+			wantErr: true,
+			errMsg:  "invalid private key format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SERVER_WALLET_PRIVATE_KEY", tt.key)
+			err := validateServerPrivateKey()
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for key %q, got nil", tt.key)
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error for key %q, got: %v", tt.key, err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateRedisURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid host:port",
+			url:     "localhost:6379",
+			wantErr: false,
+		},
+		{
+			name:    "valid redis URL",
+			url:     "redis://localhost:6379",
+			wantErr: false,
+		},
+		{
+			name:    "valid rediss URL",
+			url:     "rediss://localhost:6379",
+			wantErr: false,
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+			errMsg:  "REDIS_URL not set but CACHE_ENABLED=true",
+		},
+		{
+			name:    "invalid host:port format",
+			url:     "localhost",
+			wantErr: true,
+			errMsg:  "REDIS_URL must be in format 'host:port'",
+		},
+		{
+			name:    "invalid redis URL",
+			url:     "redis://invalid-url-format",
+			wantErr: true,
+			errMsg:  "invalid REDIS_URL format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("REDIS_URL", tt.url)
+			err := validateRedisURL()
+			
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for URL %q, got nil", tt.url)
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("expected error to contain %q, got: %v", tt.errMsg, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("expected no error for URL %q, got: %v", tt.url, err)
+				}
+			}
+		})
 	}
 }
 

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -29,6 +29,7 @@ func TestValidateConfig_WithRequiredEnv(t *testing.T) {
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CACHE_ENABLED", "false")
+	t.Setenv("RECIPIENT_ADDRESS", "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219")
 
 	err := validateConfig()
 	if err != nil {
@@ -41,6 +42,7 @@ func TestValidateConfig_CacheEnabledRequiresRedis(t *testing.T) {
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CACHE_ENABLED", "true")
 	t.Setenv("REDIS_URL", "")
+	t.Setenv("RECIPIENT_ADDRESS", "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219")
 
 	err := validateConfig()
 	if err == nil {
@@ -57,6 +59,7 @@ func TestValidateConfig_CacheEnabledWithValidRedis(t *testing.T) {
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("CACHE_ENABLED", "true")
 	t.Setenv("REDIS_URL", "localhost:6379")
+	t.Setenv("RECIPIENT_ADDRESS", "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219")
 
 	err := validateConfig()
 	if err != nil {
@@ -116,7 +119,7 @@ func TestValidateServerPrivateKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SERVER_WALLET_PRIVATE_KEY", tt.key)
 			err := validateServerPrivateKey()
-			
+
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for key %q, got nil", tt.key)
@@ -168,6 +171,24 @@ func TestValidateRedisURL(t *testing.T) {
 			errMsg:  "REDIS_URL must be in format 'host:port'",
 		},
 		{
+			name:    "invalid host:port format - empty host",
+			url:     ":6379",
+			wantErr: true,
+			errMsg:  "REDIS_URL must be in format 'host:port'",
+		},
+		{
+			name:    "invalid host:port format - empty port",
+			url:     "localhost:",
+			wantErr: true,
+			errMsg:  "REDIS_URL must be in format 'host:port'",
+		},
+		{
+			name:    "invalid host:port format - multiple colons",
+			url:     ":::",
+			wantErr: true,
+			errMsg:  "REDIS_URL must be in format 'host:port'",
+		},
+		{
 			name:    "invalid redis URL",
 			url:     "redis://invalid-url-format",
 			wantErr: true,
@@ -179,7 +200,7 @@ func TestValidateRedisURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("REDIS_URL", tt.url)
 			err := validateRedisURL()
-			
+
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for URL %q, got nil", tt.url)

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.24.0
+go 1.23
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.24.4
+go 1.24.0
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module gateway
 
-go 1.23
+go 1.24.4
 
 require (
 	github.com/ethereum/go-ethereum v1.16.8

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -55,6 +55,9 @@ type SummarizeRequest struct {
 	Text string `json:"text"`
 }
 
+// validateConfig validates all required environment variables at startup.
+// It checks for OPENROUTER_API_KEY, SERVER_WALLET_PRIVATE_KEY, and conditionally REDIS_URL.
+// Returns an error listing all missing variables if any are not set.
 func validateConfig() error {
 	required := []string{
 		"OPENROUTER_API_KEY",
@@ -93,7 +96,9 @@ func validateConfig() error {
 	return nil
 }
 
-// validateServerPrivateKey validates the private key format without loading it into memory
+// validateServerPrivateKey validates the private key format without loading it into memory.
+// It checks that the key is valid hex, has proper length (31-32 bytes), and handles 0x prefix.
+// This prevents runtime failures when the server tries to sign receipts.
 func validateServerPrivateKey() error {
 	keyHex := os.Getenv("SERVER_WALLET_PRIVATE_KEY")
 	if keyHex == "" {
@@ -120,7 +125,9 @@ func validateServerPrivateKey() error {
 	return nil
 }
 
-// validateRedisURL validates the Redis URL format without connecting
+// validateRedisURL validates the Redis URL format without connecting.
+// It supports both redis:// URLs and host:port format.
+// Only called when CACHE_ENABLED=true to ensure Redis is properly configured.
 func validateRedisURL() error {
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -143,7 +143,8 @@ func validateRedisURL() error {
 		}
 	} else {
 		// Validate host:port format
-		if !strings.Contains(redisURL, ":") {
+		parts := strings.Split(redisURL, ":")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 			return fmt.Errorf("REDIS_URL must be in format 'host:port' or 'redis://...' but got: %s", redisURL)
 		}
 	}


### PR DESCRIPTION
Fixes #99
## Summary
Implements comprehensive startup configuration validation to prevent runtime failures.

✅ Files changed: 
main.go
config_test.go
go.mod


## Changes Made
- Enhanced `validateConfig()` to check `SERVER_WALLET_PRIVATE_KEY` at startup
- Added `REDIS_URL` validation when `CACHE_ENABLED=true`
- Implemented format validation for private keys and Redis URLs
- Server now fails fast with comprehensive error messages listing ALL missing variables
- Added comprehensive test coverage for all validation scenarios

## Acceptance Criteria Met
✅ Server fails to start if `SERVER_WALLET_PRIVATE_KEY` is missing  
✅ Server fails to start if `CACHE_ENABLED=true` but `REDIS_URL` is missing  
✅ Error message lists ALL missing variables, not just the first one  
✅ Comprehensive validation with proper testing

## Testing

<img width="1193" height="326" alt="Screenshot 2026-02-04 011737" src="https://github.com/user-attachments/assets/919f4755-65bf-453d-8c37-05a05ed34446" />
<img width="872" height="427" alt="Screenshot 2026-02-04 012226" src="https://github.com/user-attachments/assets/fbeff9d9-d09b-4352-aefa-5489902af3f0" />
<img width="1113" height="278" alt="Screenshot 2026-02-04 012155" src="https://github.com/user-attachments/assets/f3ddd44f-285a-4e6f-901b-281736fb7da2" />
<img width="906" height="216" alt="Screenshot 2026-02-04 012056" src="https://github.com/user-attachments/assets/2f33ebc8-8985-463f-973f-77a82e4a41a6" />
<img width="890" height="238" alt="Screenshot 2026-02-04 012018" src="https://github.com/user-attachments/assets/ebd902d5-7974-45db-9ea0-f25e0337bc2b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened startup validation to catch missing/invalid wallet keys, enforce Redis when caching is enabled, handle 0x-prefixed keys, and surface clearer aggregated error messages.

* **Documentation**
  * Clarified required environment variables and noted REDIS_URL is required if caching is enabled.

* **Tests**
  * Added comprehensive tests for config validation, wallet key formats, and Redis URL handling.

* **Chores**
  * CI updated to run tests with a Redis service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Implemented comprehensive startup configuration validation to prevent runtime failures related to missing or malformed environment variables.

**Key changes:**
- Enhanced `validateConfig()` to require `SERVER_WALLET_PRIVATE_KEY` at startup
- Added conditional `REDIS_URL` validation when `CACHE_ENABLED=true`
- Implemented format validation for private keys (31-32 bytes, valid hex)
- Implemented Redis URL format validation (supports `redis://` URLs and `host:port`)
- Server now fails fast with error messages listing all missing variables
- Added comprehensive test coverage for validation scenarios

**Issues found:**
- `validateRedisURL()` has weak host:port validation that only checks for colon presence, accepting invalid formats like `":::"` or `"localhost:abc"`

<h3>Confidence Score: 3/5</h3>

- This PR has good validation logic but contains a bug in Redis URL validation that could cause runtime failures
- Score reflects solid implementation with comprehensive tests, but the weak host:port validation in `validateRedisURL()` allows invalid formats through that will fail at runtime, defeating the purpose of startup validation
- `gateway/main.go` requires fix to strengthen `validateRedisURL()` host:port validation logic

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/main.go | Added comprehensive startup validation for `SERVER_WALLET_PRIVATE_KEY` and `REDIS_URL`, but `validateRedisURL()` has weak host:port validation that accepts invalid formats |
| gateway/config_test.go | Added thorough test coverage for validation scenarios including edge cases for private key and Redis URL validation |
| .env.example | Updated documentation to mark `SERVER_WALLET_PRIVATE_KEY` as REQUIRED and clarify `REDIS_URL` dependency on `CACHE_ENABLED` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Main as main()
    participant VC as validateConfig()
    participant VSK as validateServerPrivateKey()
    participant VRU as validateRedisURL()
    participant GCE as getCacheEnabled()
    
    Main->>Main: Load .env file
    Main->>VC: validateConfig()
    
    VC->>VC: Check OPENROUTER_API_KEY
    VC->>VC: Check SERVER_WALLET_PRIVATE_KEY
    VC->>GCE: getCacheEnabled()
    GCE-->>VC: true/false
    
    alt CACHE_ENABLED=true
        VC->>VC: Add REDIS_URL to required list
        VC->>VC: Check REDIS_URL presence
    end
    
    VC->>VSK: validateServerPrivateKey()
    VSK->>VSK: Decode hex string
    VSK->>VSK: Check length (31-32 bytes)
    VSK-->>VC: error or nil
    
    alt CACHE_ENABLED=true
        VC->>VRU: validateRedisURL()
        VRU->>VRU: Check URL format
        VRU->>VRU: Parse redis:// URL OR check host:port
        VRU-->>VC: error or nil
    end
    
    alt validation fails
        VC-->>Main: error
        Main->>Main: Print error and exit(1)
    else validation succeeds
        VC-->>Main: nil
        Main->>Main: Print "[OK] Configuration validated"
        Main->>Main: Continue server startup
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->