### PR TITLE
Add circuit breaker and exponential backoff retries for OpenRouter calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs
 agent/
 issues/
 
+package-lock.json

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.17.2
+	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -81,6 +81,8 @@ github.com/redis/go-redis/v9 v9.17.2 h1:P2EGsA4qVIM3Pp+aPocCJ7DguDHhqrXNhVcEp4Vi
 github.com/redis/go-redis/v9 v9.17.2/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
+github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	if err := validateConfig(); err != nil {
 		fmt.Println("[Error] Missing required environment variables:")
-		fmt.Println("  -", err.Error())
+		fmt.Println(" 	-", err.Error())
 		fmt.Println()
 		fmt.Println("Copy .env.example to .env and fill in the required values.")
 		fmt.Println("See README.md for more configuration details.")
@@ -97,16 +97,16 @@ func main() {
 	}
 	fmt.Println("[OK] Configuration validated")
 	if port := os.Getenv("PORT"); port != "" {
-		fmt.Printf("    - Port: %s\n", port)
+		fmt.Printf(" 	 	- Port: %s\n", port)
 	}
 	if model := os.Getenv("MODEL"); model != "" {
-		fmt.Printf("    - Model: %s\n", model)
+		fmt.Printf(" 	 	- Model: %s\n", model)
 	}
 	if verifier := os.Getenv("VERIFIER_URL"); verifier != "" {
-		fmt.Printf("    - Verifier: %s\n", verifier)
+		fmt.Printf(" 	 	- Verifier: %s\n", verifier)
 	}
 	if chainID := os.Getenv("CHAIN_ID"); chainID != "" {
-		fmt.Printf("    - Chain ID: %s\n", chainID)
+		fmt.Printf(" 	 	- Chain ID: %s\n", chainID)
 	}
 	if os.Getenv("PORT") == "" {
 		fmt.Println("[WARN] PORT not set, using default: 3000")
@@ -541,7 +541,7 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 		return "", fmt.Errorf("failed to create OpenRouter request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer " + apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	if cid, ok := ctx.Value(correlationIDKey).(string); ok {
@@ -578,9 +578,20 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 		return "", fmt.Errorf("invalid response from AI provider")
 	}
 
-	choice := choices[0].(map[string]interface{})
-	message := choice["message"].(map[string]interface{})
-	content := message["content"].(string)
+	choice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: choice")
+	}
+
+	message, ok := choice["message"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: message")
+	}
+
+	content, ok := message["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: content")
+	}
 
 	return content, nil
 }
@@ -1059,7 +1070,7 @@ var checkOpenRouterHealth = func() string {
 	if err != nil {
 		return "unreachable"
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer " + apiKey)
 	resp, err := http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+	"github.com/sony/gobreaker"
 )
 
 type PaymentContext struct {
@@ -54,6 +55,12 @@ type SummarizeRequest struct {
 	Text string `json:"text"`
 }
 
+type VerifyResponseInternal struct {
+	IsValid          bool
+	RecoveredAddress string
+	Error            string
+}
+
 func validateConfig() error {
 	required := []string{
 		"OPENROUTER_API_KEY",
@@ -69,6 +76,7 @@ func validateConfig() error {
 	}
 	return nil
 }
+
 func main() {
 	// Try loading .env from current directory first, then fallback to parent
 	err := godotenv.Load(".env")
@@ -326,10 +334,19 @@ func handleSummarize(c *gin.Context) {
 	// 3. Call AI Service
 	summary, err := callOpenRouter(c.Request.Context(), req.Text)
 	if err != nil {
+		// ⭐ Circuit breaker open → 503
+		if err == gobreaker.ErrOpenState {
+			c.JSON(503, gin.H{"error": "Service Unavailable"})
+			return
+		}
+
+		// Existing timeout handling
 		if errors.Is(err, context.DeadlineExceeded) || c.Request.Context().Err() == context.DeadlineExceeded {
 			c.JSON(504, gin.H{"error": "Gateway Timeout", "message": "AI request timed out"})
 			return
 		}
+
+		// Fallback
 		c.JSON(500, gin.H{"error": "AI Service Failed", "details": err.Error()})
 		return
 	}
@@ -499,6 +516,7 @@ func getChainID() int {
 // the model (defaults to "z-ai/glm-4.5-air:free" if unset).
 func callOpenRouter(ctx context.Context, text string) (string, error) {
 	apiKey := os.Getenv("OPENROUTER_API_KEY")
+
 	model := os.Getenv("OPENROUTER_MODEL")
 	if model == "" {
 		model = "z-ai/glm-4.5-air:free"
@@ -517,54 +535,52 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 	if openRouterURL == "" {
 		openRouterURL = "https://openrouter.ai/api/v1/chat/completions"
 	}
+
 	req, err := http.NewRequestWithContext(ctx, "POST", openRouterURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to create OpenRouter request: %w", err)
 	}
+
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	// VIBE FIX: Pass Correlation ID to AI Service
-	// (Assuming the context has it, though OpenRouter might not use it, it's good practice)
-	if cid, ok := ctx.Value(correlationIDKey).(string); ok { // Changed to use correlationIDKey
+	if cid, ok := ctx.Value(correlationIDKey).(string); ok {
 		req.Header.Set("X-Correlation-ID", cid)
 	}
 
-	// Use http.DefaultClient and rely on ctx for cancellation/timeouts.
-	resp, err := http.DefaultClient.Do(req)
+	// ✅ Circuit breaker + retry wrapper
+	result, err := openRouterCB.Execute(func() (interface{}, error) {
+		return doRequestWithRetry(req)
+	})
+
 	if err != nil {
+		if err == gobreaker.ErrOpenState {
+			return "", gobreaker.ErrOpenState
+		}
+
 		if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 			return "", context.DeadlineExceeded
 		}
+
 		return "", err
 	}
+
+	resp := result.(*http.Response)
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	var resultBody map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&resultBody); err != nil {
 		return "", fmt.Errorf("failed to decode AI response: %w", err)
 	}
 
-	choices, ok := result["choices"].([]interface{})
+	choices, ok := resultBody["choices"].([]interface{})
 	if !ok || len(choices) == 0 {
-		log.Printf("OpenRouter response: %+v", result)
-		return "", fmt.Errorf("invalid response from AI provider: no choices")
+		return "", fmt.Errorf("invalid response from AI provider")
 	}
 
-	choice, ok := choices[0].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: malformed choice")
-	}
-
-	message, ok := choice["message"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: malformed message")
-	}
-
-	content, ok := message["content"].(string)
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: missing content")
-	}
+	choice := choices[0].(map[string]interface{})
+	message := choice["message"].(map[string]interface{})
+	content := message["content"].(string)
 
 	return content, nil
 }

--- a/gateway/openrouter_breaker.go
+++ b/gateway/openrouter_breaker.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sony/gobreaker"
+)
+
+var openRouterCB *gobreaker.CircuitBreaker
+
+func init() {
+	openRouterCB = gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        "OpenRouter",
+		MaxRequests: 5,
+		Timeout:     30 * time.Second,
+		ReadyToTrip: func(c gobreaker.Counts) bool {
+			return c.ConsecutiveFailures >= 3
+		},
+	})
+}

--- a/gateway/openrouter_retry.go
+++ b/gateway/openrouter_retry.go
@@ -7,20 +7,57 @@ import (
 )
 
 func doRequestWithRetry(req *http.Request) (*http.Response, error) {
-
 	backoff := 200 * time.Millisecond
+	maxRetries := 3
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < maxRetries; i++ {
+
+		// ------------------------------------------------
+		// Reset request body (http.Client consumes it once)
+		// ------------------------------------------------
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
 
 		resp, err := http.DefaultClient.Do(req)
 
-		if err == nil && resp.StatusCode < 500 {
-			return resp, nil
+		// ------------------------------------------------
+		// SUCCESS CASES
+		// ------------------------------------------------
+		if err == nil {
+
+			// 4xx → client error → DO NOT RETRY
+			if resp.StatusCode < 500 {
+				return resp, nil
+			}
+
+			// 5xx → retry → close body first to avoid leak
+			resp.Body.Close()
 		}
 
-		time.Sleep(backoff)
-		backoff *= 2
+		// ------------------------------------------------
+		// LAST ATTEMPT → exit
+		// ------------------------------------------------
+		if i == maxRetries-1 {
+			break
+		}
+
+		// ------------------------------------------------
+		// Context-aware backoff sleep
+		// Stops immediately if request is cancelled/timeout
+		// ------------------------------------------------
+		select {
+		case <-time.After(backoff):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+
+		backoff *= 2 // exponential backoff
 	}
 
-	return nil, fmt.Errorf("retry failed")
+	return nil, fmt.Errorf("retry failed after %d attempts", maxRetries)
 }

--- a/gateway/openrouter_retry.go
+++ b/gateway/openrouter_retry.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func doRequestWithRetry(req *http.Request) (*http.Response, error) {
+
+	backoff := 200 * time.Millisecond
+
+	for i := 0; i < 3; i++ {
+
+		resp, err := http.DefaultClient.Do(req)
+
+		if err == nil && resp.StatusCode < 500 {
+			return resp, nil
+		}
+
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+
+	return nil, fmt.Errorf("retry failed")
+}


### PR DESCRIPTION
Closes #101
## Summary
Adds resilience to OpenRouter requests by introducing:

• Circuit breaker (sony/gobreaker)
• Exponential backoff retries (3 attempts)
• Immediate 503 when provider is unhealthy

## Behavior
- Stops calling OpenRouter after consecutive failures
- Retries transient 5xx errors automatically
- Returns 503 Service Unavailable when circuit is open
- Recovers automatically (half-open → closed)

## Changes
- Added openrouter_breaker.go
- Added openrouter_retry.go


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resilience mechanisms to AI service integration, including automatic request retries and circuit breaker pattern to gracefully handle service unavailability.
  * Improved error responses with specific status codes when external services are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds circuit breaker and retry logic to OpenRouter API calls to improve resilience, but contains multiple critical bugs that will cause production issues.

**Critical Issues:**
- Resource leak: HTTP response bodies never closed during retries (4xx/5xx responses)
- Request body reuse bug: retries fail because `http.Request` body is consumed after first attempt
- Panic risk: removed safe type assertions in response parsing (main.go:581-583)
- Context ignored: retries continue past deadline, wasting resources
- Logic error: 4xx client errors trigger retries but will never succeed

**Architecture:**
- Circuit breaker configured reasonably (sony/gobreaker with 3 consecutive failures threshold)
- Returns 503 when circuit is open (good user experience)
- Exponential backoff implemented (200ms base, doubles each retry, 3 max attempts)

The retry implementation needs to be rewritten to handle request body consumption, close response bodies properly, respect context cancellation, and avoid retrying non-transient errors.

<h3>Confidence Score: 1/5</h3>

- This PR has critical bugs that will cause resource leaks, failed retries, and potential panics in production
- Multiple logic errors exist that will cause immediate production issues: HTTP body resource leaks on every retry, request body reuse preventing retries from working, removed panic protection in response parsing, and context deadline not respected during retries
- `gateway/openrouter_retry.go` requires complete rewrite, `gateway/main.go` needs type assertion safety restored

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/openrouter_retry.go | implements exponential backoff retry logic with critical bugs: body not closed on retries, request body consumed after first attempt, no context cancellation, retries 4xx errors |
| gateway/openrouter_breaker.go | configures circuit breaker with reasonable defaults (3 consecutive failures, 30s timeout, 5 max half-open requests) |
| gateway/main.go | integrates circuit breaker and retry logic into `callOpenRouter`, adds 503 handling for open circuit, but removes safe type assertions causing potential panics |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant CircuitBreaker
    participant RetryLogic
    participant OpenRouter

    Client->>Gateway: POST /summarize
    Gateway->>CircuitBreaker: Execute(doRequestWithRetry)
    
    alt Circuit Open
        CircuitBreaker-->>Gateway: ErrOpenState
        Gateway-->>Client: 503 Service Unavailable
    else Circuit Closed/Half-Open
        CircuitBreaker->>RetryLogic: doRequestWithRetry()
        
        loop Retry up to 3 times
            RetryLogic->>OpenRouter: POST /chat/completions
            
            alt Success (< 500)
                OpenRouter-->>RetryLogic: 2xx/4xx response
                RetryLogic-->>CircuitBreaker: *http.Response
                CircuitBreaker-->>Gateway: Success
                Gateway->>Gateway: Parse JSON response
                Gateway-->>Client: 200 OK with summary
            else Server Error (5xx)
                OpenRouter-->>RetryLogic: 5xx response
                Note over RetryLogic: Body not closed (leak)
                RetryLogic->>RetryLogic: Sleep with exponential backoff
            else Network Error
                OpenRouter-->>RetryLogic: connection error
                RetryLogic->>RetryLogic: Sleep with exponential backoff
            end
        end
        
        alt All retries failed
            RetryLogic-->>CircuitBreaker: error
            CircuitBreaker->>CircuitBreaker: Increment failure count
            CircuitBreaker-->>Gateway: error
            Gateway-->>Client: 500 Internal Server Error
        end
    end
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->