### PR TITLE
Fix: Add circuit breaker and safe exponential retry for OpenRouter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs
 agent/
 issues/
 
+package-lock.json

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.17.2
+	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -81,6 +81,8 @@ github.com/redis/go-redis/v9 v9.17.2 h1:P2EGsA4qVIM3Pp+aPocCJ7DguDHhqrXNhVcEp4Vi
 github.com/redis/go-redis/v9 v9.17.2/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
+github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	if err := validateConfig(); err != nil {
 		fmt.Println("[Error] Missing required environment variables:")
-		fmt.Println("  -", err.Error())
+		fmt.Println(" 	-", err.Error())
 		fmt.Println()
 		fmt.Println("Copy .env.example to .env and fill in the required values.")
 		fmt.Println("See README.md for more configuration details.")
@@ -97,16 +97,16 @@ func main() {
 	}
 	fmt.Println("[OK] Configuration validated")
 	if port := os.Getenv("PORT"); port != "" {
-		fmt.Printf("    - Port: %s\n", port)
+		fmt.Printf(" 	 	- Port: %s\n", port)
 	}
 	if model := os.Getenv("MODEL"); model != "" {
-		fmt.Printf("    - Model: %s\n", model)
+		fmt.Printf(" 	 	- Model: %s\n", model)
 	}
 	if verifier := os.Getenv("VERIFIER_URL"); verifier != "" {
-		fmt.Printf("    - Verifier: %s\n", verifier)
+		fmt.Printf(" 	 	- Verifier: %s\n", verifier)
 	}
 	if chainID := os.Getenv("CHAIN_ID"); chainID != "" {
-		fmt.Printf("    - Chain ID: %s\n", chainID)
+		fmt.Printf(" 	 	- Chain ID: %s\n", chainID)
 	}
 	if os.Getenv("PORT") == "" {
 		fmt.Println("[WARN] PORT not set, using default: 3000")
@@ -541,7 +541,7 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 		return "", fmt.Errorf("failed to create OpenRouter request: %w", err)
 	}
 
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer " + apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	if cid, ok := ctx.Value(correlationIDKey).(string); ok {
@@ -578,9 +578,20 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 		return "", fmt.Errorf("invalid response from AI provider")
 	}
 
-	choice := choices[0].(map[string]interface{})
-	message := choice["message"].(map[string]interface{})
-	content := message["content"].(string)
+	choice, ok := choices[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: choice")
+	}
+
+	message, ok := choice["message"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: message")
+	}
+
+	content, ok := message["content"].(string)
+	if !ok {
+		return "", fmt.Errorf("invalid response structure: content")
+	}
 
 	return content, nil
 }
@@ -1059,7 +1070,7 @@ var checkOpenRouterHealth = func() string {
 	if err != nil {
 		return "unreachable"
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Authorization", "Bearer " + apiKey)
 	resp, err := http.DefaultClient.Do(req)
 
 	if err != nil {

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+	"github.com/sony/gobreaker"
 )
 
 type PaymentContext struct {
@@ -54,6 +55,12 @@ type SummarizeRequest struct {
 	Text string `json:"text"`
 }
 
+type VerifyResponseInternal struct {
+	IsValid          bool
+	RecoveredAddress string
+	Error            string
+}
+
 func validateConfig() error {
 	required := []string{
 		"OPENROUTER_API_KEY",
@@ -69,6 +76,7 @@ func validateConfig() error {
 	}
 	return nil
 }
+
 func main() {
 	// Try loading .env from current directory first, then fallback to parent
 	err := godotenv.Load(".env")
@@ -326,10 +334,19 @@ func handleSummarize(c *gin.Context) {
 	// 3. Call AI Service
 	summary, err := callOpenRouter(c.Request.Context(), req.Text)
 	if err != nil {
+		// ⭐ Circuit breaker open → 503
+		if err == gobreaker.ErrOpenState {
+			c.JSON(503, gin.H{"error": "Service Unavailable"})
+			return
+		}
+
+		// Existing timeout handling
 		if errors.Is(err, context.DeadlineExceeded) || c.Request.Context().Err() == context.DeadlineExceeded {
 			c.JSON(504, gin.H{"error": "Gateway Timeout", "message": "AI request timed out"})
 			return
 		}
+
+		// Fallback
 		c.JSON(500, gin.H{"error": "AI Service Failed", "details": err.Error()})
 		return
 	}
@@ -499,6 +516,7 @@ func getChainID() int {
 // the model (defaults to "z-ai/glm-4.5-air:free" if unset).
 func callOpenRouter(ctx context.Context, text string) (string, error) {
 	apiKey := os.Getenv("OPENROUTER_API_KEY")
+
 	model := os.Getenv("OPENROUTER_MODEL")
 	if model == "" {
 		model = "z-ai/glm-4.5-air:free"
@@ -517,54 +535,52 @@ func callOpenRouter(ctx context.Context, text string) (string, error) {
 	if openRouterURL == "" {
 		openRouterURL = "https://openrouter.ai/api/v1/chat/completions"
 	}
+
 	req, err := http.NewRequestWithContext(ctx, "POST", openRouterURL, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", fmt.Errorf("failed to create OpenRouter request: %w", err)
 	}
+
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	// VIBE FIX: Pass Correlation ID to AI Service
-	// (Assuming the context has it, though OpenRouter might not use it, it's good practice)
-	if cid, ok := ctx.Value(correlationIDKey).(string); ok { // Changed to use correlationIDKey
+	if cid, ok := ctx.Value(correlationIDKey).(string); ok {
 		req.Header.Set("X-Correlation-ID", cid)
 	}
 
-	// Use http.DefaultClient and rely on ctx for cancellation/timeouts.
-	resp, err := http.DefaultClient.Do(req)
+	// ✅ Circuit breaker + retry wrapper
+	result, err := openRouterCB.Execute(func() (interface{}, error) {
+		return doRequestWithRetry(req)
+	})
+
 	if err != nil {
+		if err == gobreaker.ErrOpenState {
+			return "", gobreaker.ErrOpenState
+		}
+
 		if errors.Is(err, context.DeadlineExceeded) || ctx.Err() == context.DeadlineExceeded {
 			return "", context.DeadlineExceeded
 		}
+
 		return "", err
 	}
+
+	resp := result.(*http.Response)
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+	var resultBody map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&resultBody); err != nil {
 		return "", fmt.Errorf("failed to decode AI response: %w", err)
 	}
 
-	choices, ok := result["choices"].([]interface{})
+	choices, ok := resultBody["choices"].([]interface{})
 	if !ok || len(choices) == 0 {
-		log.Printf("OpenRouter response: %+v", result)
-		return "", fmt.Errorf("invalid response from AI provider: no choices")
+		return "", fmt.Errorf("invalid response from AI provider")
 	}
 
-	choice, ok := choices[0].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: malformed choice")
-	}
-
-	message, ok := choice["message"].(map[string]interface{})
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: malformed message")
-	}
-
-	content, ok := message["content"].(string)
-	if !ok {
-		return "", fmt.Errorf("invalid response from AI provider: missing content")
-	}
+	choice := choices[0].(map[string]interface{})
+	message := choice["message"].(map[string]interface{})
+	content := message["content"].(string)
 
 	return content, nil
 }

--- a/gateway/openrouter_breaker.go
+++ b/gateway/openrouter_breaker.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"time"
+
+	"github.com/sony/gobreaker"
+)
+
+var openRouterCB *gobreaker.CircuitBreaker
+
+func init() {
+	openRouterCB = gobreaker.NewCircuitBreaker(gobreaker.Settings{
+		Name:        "OpenRouter",
+		MaxRequests: 5,
+		Timeout:     30 * time.Second,
+		ReadyToTrip: func(c gobreaker.Counts) bool {
+			return c.ConsecutiveFailures >= 3
+		},
+	})
+}

--- a/gateway/openrouter_retry.go
+++ b/gateway/openrouter_retry.go
@@ -7,20 +7,57 @@ import (
 )
 
 func doRequestWithRetry(req *http.Request) (*http.Response, error) {
-
 	backoff := 200 * time.Millisecond
+	maxRetries := 3
 
-	for i := 0; i < 3; i++ {
+	for i := 0; i < maxRetries; i++ {
+
+		// ------------------------------------------------
+		// Reset request body (http.Client consumes it once)
+		// ------------------------------------------------
+		if req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, err
+			}
+			req.Body = body
+		}
 
 		resp, err := http.DefaultClient.Do(req)
 
-		if err == nil && resp.StatusCode < 500 {
-			return resp, nil
+		// ------------------------------------------------
+		// SUCCESS CASES
+		// ------------------------------------------------
+		if err == nil {
+
+			// 4xx → client error → DO NOT RETRY
+			if resp.StatusCode < 500 {
+				return resp, nil
+			}
+
+			// 5xx → retry → close body first to avoid leak
+			resp.Body.Close()
 		}
 
-		time.Sleep(backoff)
-		backoff *= 2
+		// ------------------------------------------------
+		// LAST ATTEMPT → exit
+		// ------------------------------------------------
+		if i == maxRetries-1 {
+			break
+		}
+
+		// ------------------------------------------------
+		// Context-aware backoff sleep
+		// Stops immediately if request is cancelled/timeout
+		// ------------------------------------------------
+		select {
+		case <-time.After(backoff):
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		}
+
+		backoff *= 2 // exponential backoff
 	}
 
-	return nil, fmt.Errorf("retry failed")
+	return nil, fmt.Errorf("retry failed after %d attempts", maxRetries)
 }

--- a/gateway/openrouter_retry.go
+++ b/gateway/openrouter_retry.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func doRequestWithRetry(req *http.Request) (*http.Response, error) {
+
+	backoff := 200 * time.Millisecond
+
+	for i := 0; i < 3; i++ {
+
+		resp, err := http.DefaultClient.Do(req)
+
+		if err == nil && resp.StatusCode < 500 {
+			return resp, nil
+		}
+
+		time.Sleep(backoff)
+		backoff *= 2
+	}
+
+	return nil, fmt.Errorf("retry failed")
+}


### PR DESCRIPTION
Closes #101

Adds resilience to OpenRouter calls:

• Circuit breaker using sony/gobreaker
• Exponential backoff retries (3 attempts)
• Reset request body using req.GetBody() before retries
• Closed resp.Body before retry to prevent connection leaks
• Context-aware backoff (no blocking sleep)
• Avoid retrying 4xx responses
• Safe type assertions in main.go to prevent panics

Implements all requested review changes and fixes production issues identified by Greptile and CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented circuit breaker protection for AI service calls, returning 503 Service Unavailable when activated.
  * Added automatic retry logic with exponential backoff (up to 3 retries) for failed requests.

* **Bug Fixes**
  * Improved error handling to map service errors to specific HTTP status codes.

* **Chores**
  * Updated .gitignore to exclude package-lock.json files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds resilience around OpenRouter calls by introducing a global circuit breaker (sony/gobreaker) and an exponential backoff retry helper that resets request bodies and closes response bodies before retrying. The summarize handler now treats an open circuit as a 503 while keeping existing 504 timeout handling.

Key merge blockers:
- `callOpenRouter` performs an unchecked `interface{}` -> `*http.Response` assertion on the circuit breaker return value, which can panic and crash the gateway if the callback ever returns an unexpected type / nil.
- The retry helper discards the underlying transport error and final response context, always returning a generic error after exhausting attempts, which breaks observability and makes failures indistinguishable in logs/metrics.

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged until the panic risk and retry error-loss issues are fixed.
- Score reflects two clear merge blockers: an unchecked type assertion on the circuit breaker result that can crash the gateway at runtime, and retry logic that discards the last transport error / final status context, making failures opaque and hard to operate.
- gateway/main.go, gateway/openrouter_retry.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Adds package-lock.json to ignored files; no functional code impact. |
| gateway/go.mod | Adds sony/gobreaker dependency for circuit breaker; otherwise unchanged. |
| gateway/go.sum | Updates module sums for sony/gobreaker; no runtime logic changes. |
| gateway/openrouter_retry.go | Introduces retry with exponential backoff and body reset; currently returns a generic error on final failure and doesn't preserve last HTTP error/response status context. |
| gateway/openrouter_breaker.go | Adds global OpenRouter circuit breaker; uses init() to set settings (trip after 3 consecutive failures). |
| gateway/main.go | Wraps OpenRouter call with circuit breaker + retry and adds 503 handling; introduces unsafe type assertion on circuit breaker result and changes error handling behavior for non-2xx responses. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant C as Client
  participant G as Gateway (gin)
  participant CB as CircuitBreaker
  participant R as RetryHelper
  participant OR as OpenRouter API

  C->>G: POST /api/ai/summarize (text + payment headers)
  G->>G: verifyPayment()
  alt payment invalid
    G-->>C: 402/403/400
  else payment valid
    G->>CB: Execute(doRequestWithRetry(req))
    alt Circuit open
      CB-->>G: ErrOpenState
      G-->>C: 503 Service Unavailable
    else Circuit closed
      CB->>R: doRequestWithRetry(req)
      loop up to 3 attempts
        R->>R: reset req.Body via req.GetBody()
        R->>OR: HTTP POST /chat/completions
        alt 2xx/4xx
          OR-->>R: resp (Status<500)
          R-->>CB: resp
        else 5xx or network error
          OR-->>R: resp 5xx / error
          R->>R: close resp.Body (if present)
          R->>R: backoff (context-aware)
        end
      end
      CB-->>G: resp
      G->>G: decode JSON choices[0].message.content
      G-->>C: 200 {result} + X-402-Receipt
    end
  end
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))

<!-- /greptile_comment -->