### PR TITLE
feat: add Redis health check to readiness probe

### DIFF
--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -461,11 +461,15 @@ func TestHandleReadyz_RedisDisabled(t *testing.T) {
 	// Save originals
 	origVerifier := checkVerifierHealth
 	origOpenRouter := checkOpenRouterHealth
-	origCacheEnabled := os.Getenv("CACHE_ENABLED")
+	origCacheEnabled, cacheWasSet := os.LookupEnv("CACHE_ENABLED")
 	defer func() {
 		checkVerifierHealth = origVerifier
 		checkOpenRouterHealth = origOpenRouter
-		os.Setenv("CACHE_ENABLED", origCacheEnabled)
+		if cacheWasSet {
+			os.Setenv("CACHE_ENABLED", origCacheEnabled)
+		} else {
+			os.Unsetenv("CACHE_ENABLED")
+		}
 	}()
 
 	// Stub healthy services
@@ -498,12 +502,16 @@ func TestHandleReadyz_RedisUnreachable(t *testing.T) {
 	// Save originals
 	origVerifier := checkVerifierHealth
 	origOpenRouter := checkOpenRouterHealth
-	origCacheEnabled := os.Getenv("CACHE_ENABLED")
+	origCacheEnabled, cacheWasSet := os.LookupEnv("CACHE_ENABLED")
 	origRedisClient := redisClient
 	defer func() {
 		checkVerifierHealth = origVerifier
 		checkOpenRouterHealth = origOpenRouter
-		os.Setenv("CACHE_ENABLED", origCacheEnabled)
+		if cacheWasSet {
+			os.Setenv("CACHE_ENABLED", origCacheEnabled)
+		} else {
+			os.Unsetenv("CACHE_ENABLED")
+		}
 		redisClient = origRedisClient
 	}()
 


### PR DESCRIPTION
closes #118 
## Description
Adds Redis health check to the `/readyz` readiness probe to prevent Kubernetes/Docker from routing traffic to pods with broken Redis connections when `CACHE_ENABLED=true`.

## Problem
The current readiness probe checks Verifier and OpenRouter health but ignores Redis. If Redis goes down while caching is enabled, the Gateway continues accepting traffic but fails on cache/nonce operations, leading to degraded service.

## Solution
Enhanced `handleReadyz()` to include Redis connectivity check:
- Sends PING command with 1-second timeout when `CACHE_ENABLED=true`
- Reports `"redis": "ok"` when healthy
- Reports `"redis": "unreachable"` when down (returns 503)
- Reports `"redis": "disabled"` when caching is off
- Overall readiness now includes Redis status in health calculation

## Changes
### Files Modified
- `gateway/main.go` - Updated `handleReadyz()` function with Redis health check
- `gateway/main_test.go` - Added 2 new test cases:
  - `TestHandleReadyz_RedisDisabled` - Verifies disabled state
  - `TestHandleReadyz_RedisUnreachable` - Verifies 503 when Redis is down

## Implementation Details

// Check Redis connectivity (if caching is enabled)
redisStatus := "disabled"
if getCacheEnabled() {
    ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
    defer cancel()
    
    if redisClient == nil {
        redisStatus = "unreachable"
    } else if err := redisClient.Ping(ctx).Err(); err != nil {
        redisStatus = "unreachable"
    } else {
        redisStatus = "ok"
    }
}
checks["redis"] = redisStatus

// Include Redis in overall readiness when caching is enabled
ready := verifierStatus == "ok" && openRouterStatus == "ok"
if getCacheEnabled() {
    ready = ready && redisStatus == "ok"


}


Testing
Unit Tests
Tests added for Redis health check scenarios. GitHub Actions CI will run all tests automatically.

Note: Local Windows testing requires CGO_ENABLED=0 due to compiler limitations, but tests pass on CI.

Manual Testing

Test 1: Redis Healthy

# With CACHE_ENABLED=true and Redis running
curl http://localhost:3000/readyz
# Expected: 200 OK, "redis": "ok", "ready": true
Test 2: Redis Disabled

# With CACHE_ENABLED=false
curl http://localhost:3000/readyz
# Expected: 200 OK, "redis": "disabled", "ready": true
Test 3: Redis Unreachable

# With CACHE_ENABLED=true and Redis stopped
docker stop microai-paygate-redis-1
curl -i http://localhost:3000/readyz
# Expected: 503 Service Unavailable, "redis": "unreachable", "ready": false
Acceptance Criteria
 /readyz returns JSON including a redis field
 If Redis is stopped, /readyz returns 503
 If Redis is running, /readyz returns 200
 Logic respects CACHE_ENABLED flag
 Tests added for Redis health check scenarios
Related Issue
Closes #118

Screenshots

<img width="1351" height="74" alt="Screenshot 2026-02-11 180645" src="https://github.com/user-attachments/assets/3a3a30eb-bc16-41d3-a962-fce4b65f6eee" />
<img width="1151" height="511" alt="Screenshot 2026-02-11 181232" src="https://github.com/user-attachments/assets/76801e53-19d4-4d13-961e-1e1c20feb3fc" />
<img width="1393" height="61" alt="Screenshot 2026-02-11 181243" src="https://github.com/user-attachments/assets/374ab94e-d93a-49e2-b2ad-357b0232f6f7" />
<img width="1404" height="508" alt="Screenshot 2026-02-11 181310" src="https://github.com/user-attachments/assets/14b6a2e5-70de-4b33-ae75-69f4190fca6d" />
<img width="577" height="89" alt="Screenshot 2026-02-11 181317" src="https://github.com/user-attachments/assets/973063b7-379b-426f-9eb3-8aa0e495076f" />
<img width="1397" height="122" alt="Screenshot 2026-02-11 181329" src="https://github.com/user-attachments/assets/5b203d62-92be-4ecf-a87c-a616c69d010c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Readiness probe now includes Redis health when caching is enabled; overall readiness requires Redis to be reachable and the readiness response reports Redis status.

* **Tests**
  * Added tests covering Redis-disabled and Redis-unreachable scenarios for the readiness check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the gateway readiness probe (`GET /readyz`) to include Redis connectivity when caching is enabled (`CACHE_ENABLED=true`). The handler now records a `checks.redis` status (`ok`/`unreachable`/`disabled`) and gates overall readiness on Redis health only when caching is enabled, returning 503 when any required dependency is unhealthy.

Tests were added to cover the Redis-disabled case and the Redis-unreachable (nil client) case alongside the existing verifier/OpenRouter checks.

<h3>Confidence Score: 4/5</h3>

- This PR is mostly safe to merge once the test environment leak is fixed.
- Core readiness logic is straightforward and consistent with existing health checks; main risk is in the added tests, which restore CACHE_ENABLED using Setenv and can leave the variable set (empty) when it was originally unset, potentially impacting later tests.
- gateway/main_test.go (env restoration/cleanup logic)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/main.go | Adds Redis PING check to /readyz when CACHE_ENABLED=true and includes redis status in readiness calculation. |
| gateway/main_test.go | Adds tests for redis readiness states; teardown restores env via Setenv which can leak state when var was originally unset. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant K8s as K8s/Docker
    participant GW as Gateway (/readyz)
    participant V as Verifier
    participant OR as OpenRouter
    participant R as Redis

    K8s->>GW: GET /readyz
    GW->>V: GET /health (2s timeout)
    V-->>GW: 200 / non-200 / error
    GW->>OR: GET /api/v1/models (2s timeout)
    OR-->>GW: 200 / non-200 / error

    alt CACHE_ENABLED=true
        GW->>R: PING (1s timeout)
        R-->>GW: PONG / error
    else CACHE_ENABLED=false
        Note over GW: redis status = "disabled"
    end

    GW-->>K8s: 200 if ready else 503
    Note over K8s,GW: Response includes checks.{verifier, openrouter, redis, gateway}
```

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))

<!-- /greptile_comment -->