### PR TITLE
feat(metrics): add Prometheus instrumentation and expose /metrics end…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ VERIFIER_TIMEOUT_SECONDS=2
 # Health check timeout (seconds)
 HEALTH_CHECK_TIMEOUT_SECONDS=2
 
+# Metrics / Observability
+# Enable the gateway Prometheus endpoint (default: true)
+METRICS_ENABLED=true
+# Gateway Prometheus endpoint path (default: /metrics)
+METRICS_PATH=/metrics
+
 
 
 # Redis Configuration (for Caching and Redis-backed Receipts)

--- a/.env.production.example
+++ b/.env.production.example
@@ -46,6 +46,13 @@ AI_REQUEST_TIMEOUT_SECONDS=30
 VERIFIER_TIMEOUT_SECONDS=60
 HEALTH_CHECK_TIMEOUT_SECONDS=2
 
+# Metrics / Observability
+# Prometheus metrics are disabled in this production template so the endpoint
+# is not exposed accidentally. Set true only when protected by your platform,
+# private network, or scrape allowlist.
+METRICS_ENABLED=false
+METRICS_PATH=/metrics
+
 NEXT_PUBLIC_GATEWAY_URL=https://<gateway-app>.onrender.com
 # Optional but recommended: lets the cold-start banner pre-warm the verifier
 # in parallel with the gateway, so the first signed-request click is fast.

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ Core local variables live in [.env.example](.env.example). Production placeholde
 | `REDIS_URL` | Gateway | Required when `RECEIPT_STORE=redis` or `CACHE_ENABLED=true`. |
 | `VERIFIER_URL` | Gateway | **Required.** Where the gateway calls `/verify` (e.g. `http://127.0.0.1:3002` for `bun run stack`, `https://<app>.onrender.com` for Render). The gateway refuses to start if unset — no silent loopback fallback. |
 | `CACHE_ENABLED` | Gateway | Optional response cache. Payment verification still runs on cache hits. |
+| `METRICS_ENABLED` | Gateway | Enables the Prometheus metrics endpoint by default. Set to `false` to disable. |
+| `METRICS_PATH` | Gateway | Gateway metrics path. Default `/metrics`; values without a leading slash are normalized. |
 | `ALLOWED_ORIGINS` | Gateway | Comma-separated CORS origins, no paths or query strings. |
 | `TRUSTED_PROXIES` | Gateway | Comma-separated trusted proxy CIDRs for production IP handling. |
 | `NEXT_PUBLIC_GATEWAY_URL` | Web | Gateway base URL. Browser fetches `/api/ai/summarize` and `/api/receipts/:id` here. |
@@ -361,6 +363,7 @@ The gateway serves OpenAPI at `GET /openapi.yaml` and Swagger UI at `GET /docs`.
 | --- | --- |
 | `GET /healthz` | Liveness check for the gateway process. |
 | `GET /readyz` | Readiness check for verifier, active AI provider, Redis when required, and the gateway's own metrics. |
+| `GET /metrics` | Prometheus metrics for gateway request rate, latency, cache, verification, rate-limit, and active-request signals. |
 | `POST /api/ai/summarize` | Payment-gated text summarization endpoint. |
 | `GET /api/receipts/{id}` | Fetch a stored signed receipt until its TTL expires. |
 
@@ -381,6 +384,23 @@ Successful summarize responses return:
 ```
 
 The signed receipt is returned in the `X-402-Receipt` response header as base64-encoded `SignedReceipt` JSON.
+
+## Observability
+
+The gateway exposes Prometheus metrics at `GET /metrics` by default. Set `METRICS_ENABLED=false` to disable the endpoint, or set `METRICS_PATH` to move it. The verifier exposes Prometheus metrics at `GET /metrics` on port `3002`.
+
+```yaml
+scrape_configs:
+  - job_name: microai-gateway
+    static_configs:
+      - targets: ["localhost:3000"]
+    metrics_path: /metrics
+
+  - job_name: microai-verifier
+    static_configs:
+      - targets: ["localhost:3002"]
+    metrics_path: /metrics
+```
 
 ## Benchmarking
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3001}
       - RECEIPT_STORE=${RECEIPT_STORE:-redis}
       - CHAIN_ID=${CHAIN_ID:-84532}
+      - METRICS_ENABLED=${METRICS_ENABLED:-true}
+      - METRICS_PATH=${METRICS_PATH:-/metrics}
       # Pass through from .env file
       - OPENROUTER_API_KEY
       - OPENROUTER_MODEL

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -47,6 +47,7 @@ sequenceDiagram
 | --- | --- |
 | `GET /healthz` | Liveness check for gateway process health. |
 | `GET /readyz` | Dependency readiness check for verifier, active AI provider, Redis when required, and gateway self metrics. |
+| `GET /metrics` | Prometheus metrics endpoint when `METRICS_ENABLED` is not `false`. |
 | `GET /openapi.yaml` | OpenAPI 3.1 contract for public gateway endpoints. |
 | `GET /docs` | Swagger UI backed by `openapi.yaml`. |
 | `POST /api/ai/summarize` | Payment-gated summarize endpoint. |
@@ -67,7 +68,8 @@ The verifier route `POST /verify` is not a gateway route. It belongs to the inte
 | `redis.go` | Redis client and response cache configuration. |
 | `cache.go` | Optional response cache. Cache hits still require valid payment verification. |
 | `ratelimit.go` | Token bucket implementation. |
-| `middleware.go` | Request timeout and correlation ID middleware. |
+| `metrics.go` | Prometheus metric definitions and metrics endpoint config helpers. |
+| `middleware.go` | Request timeout, correlation ID, and request metrics middleware. |
 | `internal/ai/` | OpenRouter and Ollama provider implementations. |
 | `openapi.yaml` | Public gateway API contract. |
 
@@ -101,6 +103,8 @@ Common optional variables:
 | `RECEIPT_TTL` | `86400` | Receipt TTL in seconds. |
 | `CACHE_ENABLED` | `false` | Optional response cache. |
 | `CACHE_TTL_SECONDS` | `3600` | Response cache TTL. |
+| `METRICS_ENABLED` | enabled unless set to `false` | Exposes Prometheus metrics. |
+| `METRICS_PATH` | `/metrics` | Gateway metrics endpoint path. Missing leading slash is normalized. |
 | `RATE_LIMIT_ENABLED` | disabled unless set to `true` or `1` | Enables token bucket middleware. |
 | `REQUEST_TIMEOUT_SECONDS` | `60` | Global request timeout. |
 | `AI_REQUEST_TIMEOUT_SECONDS` | `30` | AI route timeout. |
@@ -137,6 +141,20 @@ go vet ./...
 ```
 
 Run gateway tests after changing handlers, middleware, config parsing, receipt storage, cache, Redis, rate limits, OpenAPI, or provider behavior.
+
+## Metrics
+
+The gateway emits Prometheus metrics for HTTP request counts and durations, cache hits and misses, verifier outcomes, rate-limit rejections, and active requests. The default endpoint is `GET /metrics`.
+
+Example local scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: microai-gateway
+    static_configs:
+      - targets: ["localhost:3000"]
+    metrics_path: /metrics
+```
 
 ## API Errors
 

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -139,6 +139,10 @@ func CacheMiddleware() gin.HandlerFunc {
 			}
 			verifyResp, paymentCtx, err := verifyPayment(c.Request.Context(), signature, nonce, timestamp)
 			if err != nil {
+
+				verificationTotal.WithLabelValues("error").Inc()
+				log.Printf("Verification error on cache hit: %v", err)
+
 				if errors.Is(err, context.DeadlineExceeded) {
 					respondError(c, 504, "verifier_timeout", err)
 				} else {
@@ -149,16 +153,28 @@ func CacheMiddleware() gin.HandlerFunc {
 			}
 
 			if !verifyResp.IsValid {
+
 				respondVerificationFailure(c, verifyResp)
 				c.Abort()
 				return
 			}
 			if verifyResp.RecoveredAddress == "" {
 				respondError(c, 502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
+
+				// Check for timestamp-related errors (E007, E008, E009)
+				verificationTotal.WithLabelValues("error").Inc()
+				if strings.HasPrefix(verifyResp.Error, "E007") ||
+					strings.HasPrefix(verifyResp.Error, "E008") ||
+					strings.HasPrefix(verifyResp.Error, "E009") {
+					c.JSON(400, gin.H{"error": "Invalid timestamp", "details": verifyResp.Error})
+				} else {
+					c.JSON(403, gin.H{"error": "Invalid Signature", "details": verifyResp.Error})
+				}
+
 				c.Abort()
 				return
 			}
-
+			verificationTotal.WithLabelValues("success").Inc()
 			// Payment Verified. Store verification for downstream if needed (though we abort)
 			c.Set("payment_verification", verifyResp)
 			c.Set("payment_context", paymentCtx)
@@ -183,7 +199,7 @@ func CacheMiddleware() gin.HandlerFunc {
 		if routePath == "" {
 			routePath = "unknown"
 		}
-		cacheHits.WithLabelValues(routePath).Inc()
+		cacheMisses.WithLabelValues(routePath).Inc()
 
 		// Prepare to capture response
 		writer := &cachedWriter{

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -122,7 +122,7 @@ func CacheMiddleware() gin.HandlerFunc {
 				routePath = "unknown"
 			}
 			cacheHits.WithLabelValues(routePath).Inc()
-			
+
 			// Cache HIT! -> Verify Payment *BEFORE* serving
 			// verifyPayment creates its own timeout context, so pass request context directly
 			timestampStr := c.GetHeader("X-402-Timestamp")
@@ -160,7 +160,7 @@ func CacheMiddleware() gin.HandlerFunc {
 			}
 			if verifyResp.RecoveredAddress == "" {
 				verificationTotal.WithLabelValues("error").Inc()
-				respondError(c,502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
+				respondError(c, 502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
 				c.Abort()
 				return
 			}

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -153,24 +153,14 @@ func CacheMiddleware() gin.HandlerFunc {
 			}
 
 			if !verifyResp.IsValid {
-
+				verificationTotal.WithLabelValues("error").Inc()
 				respondVerificationFailure(c, verifyResp)
 				c.Abort()
 				return
 			}
 			if verifyResp.RecoveredAddress == "" {
-				respondError(c, 502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
-
-				// Check for timestamp-related errors (E007, E008, E009)
 				verificationTotal.WithLabelValues("error").Inc()
-				if strings.HasPrefix(verifyResp.Error, "E007") ||
-					strings.HasPrefix(verifyResp.Error, "E008") ||
-					strings.HasPrefix(verifyResp.Error, "E009") {
-					c.JSON(400, gin.H{"error": "Invalid timestamp", "details": verifyResp.Error})
-				} else {
-					c.JSON(403, gin.H{"error": "Invalid Signature", "details": verifyResp.Error})
-				}
-
+				respondError(c,502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
 				c.Abort()
 				return
 			}

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -117,6 +117,12 @@ func CacheMiddleware() gin.HandlerFunc {
 		if cached, err := getFromCache(c.Request.Context(), cacheKey); err == nil {
 			log.Printf("Cache HIT: %s", cacheKey)
 
+			routePath := c.FullPath()
+			if routePath == "" {
+				routePath = "unknown"
+			}
+			cacheHits.WithLabelValues(routePath).Inc()
+			
 			// Cache HIT! -> Verify Payment *BEFORE* serving
 			// verifyPayment creates its own timeout context, so pass request context directly
 			timestampStr := c.GetHeader("X-402-Timestamp")
@@ -172,6 +178,12 @@ func CacheMiddleware() gin.HandlerFunc {
 
 		// Cache MISS
 		log.Printf("Cache MISS: %s", cacheKey)
+
+		routePath := c.FullPath()
+		if routePath == "" {
+			routePath = "unknown"
+		}
+		cacheHits.WithLabelValues(routePath).Inc()
 
 		// Prepare to capture response
 		writer := &cachedWriter{

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -153,7 +153,7 @@ func CacheMiddleware() gin.HandlerFunc {
 			}
 
 			if !verifyResp.IsValid {
-				verificationTotal.WithLabelValues("error").Inc()
+				verificationTotal.WithLabelValues("invalid").Inc()
 				respondVerificationFailure(c, verifyResp)
 				c.Abort()
 				return

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -19,6 +20,7 @@ require (
 
 require (
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.14.1 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
@@ -41,13 +43,18 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.6.2 // indirect
+	github.com/prometheus/common v0.66.1 // indirect
+	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.57.0 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.3.0 // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/arch v0.22.0 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/holiman/uint256 v1.3.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -1,7 +1,12 @@
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
+
 github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
 github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
+
+github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
+github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
@@ -60,12 +65,16 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -75,10 +84,20 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
+github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
 github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
+github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
+github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
+github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
+github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
+github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
+github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzMyRg=
+github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
@@ -100,10 +119,17 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA=
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
+
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
+
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+
 go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
 go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/arch v0.22.0 h1:c/Zle32i5ttqRXjdLyyHZESLD/bB90DCU1g9l/0YBDI=
 golang.org/x/arch v0.22.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -287,13 +287,22 @@ func main() {
 	// including those rejected by later middleware, carries an ID for tracing.
 	r.Use(CorrelationIDMiddleware())
 
-	if os.Getenv("METRICS_ENABLED") != "false" {
+	enabled := strings.ToLower(
+		strings.TrimSpace(os.Getenv("METRICS_ENABLED")),
+	) != "false"
+
+	if enabled{
 		r.Use(MetricsMiddleware())
-		
-		path := os.Getenv("METRICS_PATH")
+
+		path := strings.TrimSpace(os.Getenv("METRICS_PATH"))
+
 		if path == "" {
 			path = "/metrics"
 		}
+	// Gin requires routes to start with "/"
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
 		r.GET(path, gin.WrapH(promhttp.Handler()))
 	}
 
@@ -457,6 +466,8 @@ func handleSummarize(c *gin.Context) {
 	}
 
 	if !verifyResp.IsValid {
+		verificationTotal.WithLabelValues("invalid").Inc()
+
 		respondVerificationFailure(c, verifyResp)
 		return
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -288,6 +288,9 @@ func main() {
 	metricsPath := getMetricsPath()
 
 	if getMetricsEnabled() {
+		if err := validateMetricsPath(metricsPath); err != nil {
+			log.Fatalf("Invalid metrics configuration: %v", err)
+		}
 		r.Use(MetricsMiddleware())
 		r.GET(metricsPath, gin.WrapH(promhttp.Handler()))
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -297,11 +297,6 @@ func main() {
 		r.GET(path, gin.WrapH(promhttp.Handler()))
 	}
 
-
-	// VIBE FIX: Register the Correlation ID Middleware immediately
-	// This ensures every single request gets an ID before anything else happens.
-	r.Use(CorrelationIDMiddleware())
-
 	// Configure GZIP compression for API responses
 	// - Uses DefaultCompression for balance between speed and size
 	// - Excludes /metrics endpoint (if added in future)
@@ -451,6 +446,8 @@ func handleSummarize(c *gin.Context) {
 	// Verify
 	verifyResp, paymentCtx, err := verifyPayment(c.Request.Context(), signature, nonce, uint64(timestampValue))
 	if err != nil {
+		verificationTotal.WithLabelValues("error").Inc()
+
 		if errors.Is(err, context.DeadlineExceeded) {
 			respondError(c, 504, "verifier_timeout", err)
 		} else {
@@ -468,6 +465,8 @@ func handleSummarize(c *gin.Context) {
 		return
 	}
 
+	verificationTotal.WithLabelValues("success").Inc()
+	
 	// 2. Parse Request
 	var req SummarizeRequest
 	if err := json.Unmarshal(requestBody, &req); err != nil {
@@ -694,6 +693,9 @@ func RateLimitMiddleware(limiters map[string]RateLimiter) gin.HandlerFunc {
 		// Check if request is allowed
 		if !limiter.Allow(key) {
 			retryAfter := calculateRetryAfter(limiter, key)
+
+			rateLimitHits.WithLabelValues(c.FullPath()).Inc()
+
 			c.Header("Retry-After", strconv.Itoa(retryAfter))
 			c.Header("X-RateLimit-Limit", strconv.Itoa(getLimitForTier(tier)))
 			c.Header("X-RateLimit-Remaining", "0")

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -266,8 +266,6 @@ func main() {
 
 	r := gin.Default()
 
-
-
 	// Restrict trusted proxies to prevent X-Forwarded-For spoofing.
 	// IP-based rate limiting relies on c.ClientIP(), which reads
 	// X-Forwarded-For only from proxies in this list. An empty list
@@ -287,30 +285,18 @@ func main() {
 	// including those rejected by later middleware, carries an ID for tracing.
 	r.Use(CorrelationIDMiddleware())
 
-	enabled := strings.ToLower(
-		strings.TrimSpace(os.Getenv("METRICS_ENABLED")),
-	) != "false"
+	metricsPath := getMetricsPath()
 
-	if enabled{
+	if getMetricsEnabled() {
 		r.Use(MetricsMiddleware())
-
-		path := strings.TrimSpace(os.Getenv("METRICS_PATH"))
-
-		if path == "" {
-			path = "/metrics"
-		}
-	// Gin requires routes to start with "/"
-	if !strings.HasPrefix(path, "/") {
-		path = "/" + path
-	}
-		r.GET(path, gin.WrapH(promhttp.Handler()))
+		r.GET(metricsPath, gin.WrapH(promhttp.Handler()))
 	}
 
 	// Configure GZIP compression for API responses
 	// - Uses DefaultCompression for balance between speed and size
 	// - Excludes /metrics endpoint (if added in future)
 	// - Compression is transparent to receipt verification (hashes uncompressed body)
-	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{"/metrics"})))
+	r.Use(gzip.Gzip(gzip.DefaultCompression, gzip.WithExcludedPaths([]string{metricsPath})))
 
 	// Initialize Redis early to fail-fast if Redis required but unavailable
 	if err := initRedis(); err != nil {
@@ -477,7 +463,7 @@ func handleSummarize(c *gin.Context) {
 	}
 
 	verificationTotal.WithLabelValues("success").Inc()
-	
+
 	// 2. Parse Request
 	var req SummarizeRequest
 	if err := json.Unmarshal(requestBody, &req); err != nil {
@@ -1169,6 +1155,3 @@ var checkOpenRouterHealth = func() string {
 	}
 	return "ok"
 }
-
-
-

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -267,6 +267,7 @@ func main() {
 	r := gin.Default()
 
 
+
 	// Restrict trusted proxies to prevent X-Forwarded-For spoofing.
 	// IP-based rate limiting relies on c.ClientIP(), which reads
 	// X-Forwarded-For only from proxies in this list. An empty list
@@ -299,7 +300,6 @@ func main() {
 
 	// VIBE FIX: Register the Correlation ID Middleware immediately
 	// This ensures every single request gets an ID before anything else happens.
->>>>>>> 46836ba (feat(metrics): add Prometheus instrumentation and expose /metrics endpoint)
 	r.Use(CorrelationIDMiddleware())
 
 	// Configure GZIP compression for API responses
@@ -1157,7 +1157,5 @@ var checkOpenRouterHealth = func() string {
 	return "ok"
 }
 
-// r := gin.New()
 
-// r.use(MetricsMiddleware())
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/joho/godotenv"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 type PaymentContext struct {
@@ -265,6 +266,7 @@ func main() {
 
 	r := gin.Default()
 
+
 	// Restrict trusted proxies to prevent X-Forwarded-For spoofing.
 	// IP-based rate limiting relies on c.ClientIP(), which reads
 	// X-Forwarded-For only from proxies in this list. An empty list
@@ -282,6 +284,22 @@ func main() {
 
 	// Register the Correlation ID middleware first so every request,
 	// including those rejected by later middleware, carries an ID for tracing.
+	r.Use(CorrelationIDMiddleware())
+
+	if os.Getenv("METRICS_ENABLED") != "false" {
+		r.Use(MetricsMiddleware())
+		
+		path := os.Getenv("METRICS_PATH")
+		if path == "" {
+			path = "/metrics"
+		}
+		r.GET(path, gin.WrapH(promhttp.Handler()))
+	}
+
+
+	// VIBE FIX: Register the Correlation ID Middleware immediately
+	// This ensures every single request gets an ID before anything else happens.
+>>>>>>> 46836ba (feat(metrics): add Prometheus instrumentation and expose /metrics endpoint)
 	r.Use(CorrelationIDMiddleware())
 
 	// Configure GZIP compression for API responses
@@ -1138,3 +1156,8 @@ var checkOpenRouterHealth = func() string {
 	}
 	return "ok"
 }
+
+// r := gin.New()
+
+// r.use(MetricsMiddleware())
+

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -695,7 +695,11 @@ func RateLimitMiddleware(limiters map[string]RateLimiter) gin.HandlerFunc {
 		if !limiter.Allow(key) {
 			retryAfter := calculateRetryAfter(limiter, key)
 
-			rateLimitHits.WithLabelValues(c.FullPath()).Inc()
+			routePath := c.FullPath()
+			if routePath == "" {
+				routePath = "unknown"
+			}
+			rateLimitHits.WithLabelValues(routePath).Inc()
 
 			c.Header("Retry-After", strconv.Itoa(retryAfter))
 			c.Header("X-RateLimit-Limit", strconv.Itoa(getLimitForTier(tier)))

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -461,6 +461,7 @@ func handleSummarize(c *gin.Context) {
 		return
 	}
 	if verifyResp.RecoveredAddress == "" {
+		verificationTotal.WithLabelValues("error").Inc()
 		respondError(c, 502, "verification_unavailable", fmt.Errorf("verifier success missing recovered_address"))
 		return
 	}

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -21,6 +22,15 @@ func getMetricsPath() string {
 		return "/" + path
 	}
 	return path
+}
+
+func validateMetricsPath(path string) error {
+	switch path {
+	case "/healthz", "/readyz", "/docs", "/openapi.yaml", "/api/ai/summarize", "/api/receipts/:id":
+		return fmt.Errorf("metrics path %q conflicts with an existing route", path)
+	default:
+		return nil
+	}
 }
 
 var (

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -28,9 +28,11 @@ func validateMetricsPath(path string) error {
 	switch path {
 	case "/healthz", "/readyz", "/docs", "/openapi.yaml", "/api/ai/summarize", "/api/receipts/:id":
 		return fmt.Errorf("metrics path %q conflicts with an existing route", path)
-	default:
-		return nil
 	}
+	if strings.HasPrefix(path, "/api/receipts/") {
+		return fmt.Errorf("metrics path %q conflicts with the receipt lookup route", path)
+	}
+	return nil
 }
 
 var (

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -25,6 +25,9 @@ func getMetricsPath() string {
 }
 
 func validateMetricsPath(path string) error {
+	if strings.ContainsAny(path, ":*") {
+		return fmt.Errorf("metrics path %q must be a literal route without Gin wildcards", path)
+	}
 	switch path {
 	case "/healthz", "/readyz", "/docs", "/openapi.yaml", "/api/ai/summarize", "/api/receipts/:id":
 		return fmt.Errorf("metrics path %q conflicts with an existing route", path)

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	requestsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_requests_total",
+			Help: "Total number of HTTP requests",
+		},
+		[]string{"method", "path", "status"},
+	)
+	requestsDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "gateway_requests_duration_seconds",
+			Help: "Request duration in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"method", "path"},
+	)
+	cacheHits = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_cache_hits_total",
+			Help: "Total cache hits",
+		},
+		[]string{"path"},
+	)
+	cacheMisses = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_cache_misses_total",
+			Help: "Total cache misses",
+		},
+		[]string{"path"},
+	)
+	rateLimitHits = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_rate_limit_hits_total",
+			Help: "Rate limit rejections",
+		},
+		[]string{"path"},
+	)
+	verificationTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "gateway_verification_total",
+			Help: "Signature verification results",
+		},
+		[]string{"result"},
+	)
+	activeRequests = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "gateway_active_requests",
+			Help: "Current in-flight requests",
+		},
+	)
+)	

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -15,7 +15,7 @@ var (
 	)
 	requestsDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "gateway_requests_duration_seconds",
+			Name: "gateway_request_duration_seconds",
 			Help: "Request duration in seconds",
 			Buckets: prometheus.DefBuckets,
 		},

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -1,9 +1,27 @@
 package main
 
 import (
+	"os"
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
+
+func getMetricsEnabled() bool {
+	return strings.ToLower(strings.TrimSpace(os.Getenv("METRICS_ENABLED"))) != "false"
+}
+
+func getMetricsPath() string {
+	path := strings.TrimSpace(os.Getenv("METRICS_PATH"))
+	if path == "" {
+		return "/metrics"
+	}
+	if !strings.HasPrefix(path, "/") {
+		return "/" + path
+	}
+	return path
+}
 
 var (
 	requestsTotal = promauto.NewCounterVec(
@@ -15,8 +33,8 @@ var (
 	)
 	requestsDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: "gateway_request_duration_seconds",
-			Help: "Request duration in seconds",
+			Name:    "gateway_request_duration_seconds",
+			Help:    "Request duration in seconds",
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"method", "path"},
@@ -55,4 +73,4 @@ var (
 			Help: "Current in-flight requests",
 		},
 	)
-)	
+)

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -43,7 +43,16 @@ func TestMetricsPathRejectsReservedRoutes(t *testing.T) {
 	require.NoError(t, validateMetricsPath("/metrics"))
 	require.NoError(t, validateMetricsPath("/internal/metrics"))
 
-	for _, path := range []string{"/healthz", "/readyz", "/docs", "/openapi.yaml", "/api/ai/summarize", "/api/receipts/:id"} {
+	for _, path := range []string{
+		"/healthz",
+		"/readyz",
+		"/docs",
+		"/openapi.yaml",
+		"/api/ai/summarize",
+		"/api/receipts/:id",
+		"/api/receipts/metrics",
+		"/api/receipts/metrics/nested",
+	} {
 		t.Run(path, func(t *testing.T) {
 			require.Error(t, validateMetricsPath(path))
 		})

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -151,3 +151,32 @@ func TestCacheMiddlewareRecordsHitsAndMisses(t *testing.T) {
 	hitAfter := testutil.ToFloat64(cacheHits.WithLabelValues("/api/ai/summarize"))
 	require.Equal(t, float64(1), hitAfter-hitBefore)
 }
+
+func TestCacheHitVerificationMetricRecordsInvalidResponses(t *testing.T) {
+	origClient := redisClient
+	redisServer := miniredis.RunT(t)
+	redisClient = redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		if redisClient != nil && redisClient != origClient {
+			_ = redisClient.Close()
+		}
+		redisClient = origClient
+	})
+
+	withVerifierResponse(t, http.StatusOK, `{"is_valid":false,"recovered_address":null,"error":"bad signature"}`)
+	router := newCachedSummarizeTestRouter()
+
+	hitText := "cache hit invalid metrics"
+	cachedBody := `{"result":"cached summary","cached_at":1700000000}`
+	cacheKey := getCacheKey(hitText, "z-ai/glm-4.5-air:free")
+	require.NoError(t, redisClient.Set(context.Background(), cacheKey, cachedBody, time.Hour).Err())
+
+	before := testutil.ToFloat64(verificationTotal.WithLabelValues("invalid"))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, signedSummarizeRequest(`{"text":"`+hitText+`"}`))
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	after := testutil.ToFloat64(verificationTotal.WithLabelValues("invalid"))
+	require.Equal(t, float64(1), after-before)
+}

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -52,6 +52,10 @@ func TestMetricsPathRejectsReservedRoutes(t *testing.T) {
 		"/api/receipts/:id",
 		"/api/receipts/metrics",
 		"/api/receipts/metrics/nested",
+		"/:name",
+		"/api/:name",
+		"/*path",
+		"/metrics/*rest",
 	} {
 		t.Run(path, func(t *testing.T) {
 			require.Error(t, validateMetricsPath(path))

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -60,6 +60,26 @@ func TestMetricsMiddlewareRecordsTimeoutStatus(t *testing.T) {
 	require.Equal(t, float64(1), after-before)
 }
 
+func TestMetricsMiddlewareRecordsPanickedRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(MetricsMiddleware())
+	r.GET("/panic-metrics", func(c *gin.Context) {
+		panic("boom")
+	})
+
+	before := testutil.ToFloat64(requestsTotal.WithLabelValues("GET", "/panic-metrics", "500"))
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/panic-metrics", nil)
+	r.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusInternalServerError, recorder.Code)
+	after := testutil.ToFloat64(requestsTotal.WithLabelValues("GET", "/panic-metrics", "500"))
+	require.Equal(t, float64(1), after-before)
+}
+
 func TestRateLimitMiddlewareRecordsRejectedRequests(t *testing.T) {
 	t.Setenv("RATE_LIMIT_ENABLED", "true")
 	t.Setenv("RATE_LIMIT_ANONYMOUS_RPM", "60")

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -115,6 +115,27 @@ func TestRateLimitMiddlewareRecordsRejectedRequests(t *testing.T) {
 	require.Equal(t, float64(1), after-before)
 }
 
+func TestRateLimitMiddlewareRecordsUnknownRouteLabel(t *testing.T) {
+	t.Setenv("RATE_LIMIT_ENABLED", "true")
+	t.Setenv("RATE_LIMIT_ANONYMOUS_RPM", "60")
+	t.Setenv("RATE_LIMIT_ANONYMOUS_BURST", "1")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RateLimitMiddleware(initRateLimiters()))
+
+	before := testutil.ToFloat64(rateLimitHits.WithLabelValues("unknown"))
+
+	for i := 0; i < 2; i++ {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/not-registered", nil)
+		r.ServeHTTP(recorder, req)
+	}
+
+	after := testutil.ToFloat64(rateLimitHits.WithLabelValues("unknown"))
+	require.Equal(t, float64(1), after-before)
+}
+
 func TestGatewayVerificationMetricRecordsInvalidResponses(t *testing.T) {
 	withVerifierResponse(t, http.StatusOK, `{"is_valid":false,"recovered_address":null,"error":"bad signature"}`)
 	router := newSummarizeTestRouter()

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMetricsEnabledDefaultsAndFalseVariants(t *testing.T) {
+	t.Setenv("METRICS_ENABLED", "")
+	require.True(t, getMetricsEnabled())
+
+	t.Setenv("METRICS_ENABLED", "false")
+	require.False(t, getMetricsEnabled())
+
+	t.Setenv("METRICS_ENABLED", "False")
+	require.False(t, getMetricsEnabled())
+
+	t.Setenv("METRICS_ENABLED", "FALSE")
+	require.False(t, getMetricsEnabled())
+}
+
+func TestGetMetricsPathDefaultsAndNormalizesSlash(t *testing.T) {
+	t.Setenv("METRICS_PATH", "")
+	require.Equal(t, "/metrics", getMetricsPath())
+
+	t.Setenv("METRICS_PATH", "internal/metrics")
+	require.Equal(t, "/internal/metrics", getMetricsPath())
+
+	t.Setenv("METRICS_PATH", "/custom-metrics")
+	require.Equal(t, "/custom-metrics", getMetricsPath())
+}
+
+func TestMetricsMiddlewareRecordsTimeoutStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(MetricsMiddleware())
+	r.Use(RequestTimeoutMiddleware(10 * time.Millisecond))
+	r.GET("/metrics-timeout-status", func(c *gin.Context) {
+		time.Sleep(50 * time.Millisecond)
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	before := testutil.ToFloat64(requestsTotal.WithLabelValues("GET", "/metrics-timeout-status", "504"))
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/metrics-timeout-status", nil)
+	r.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusGatewayTimeout, recorder.Code)
+	after := testutil.ToFloat64(requestsTotal.WithLabelValues("GET", "/metrics-timeout-status", "504"))
+	require.Equal(t, float64(1), after-before)
+}
+
+func TestRateLimitMiddlewareRecordsRejectedRequests(t *testing.T) {
+	t.Setenv("RATE_LIMIT_ENABLED", "true")
+	t.Setenv("RATE_LIMIT_ANONYMOUS_RPM", "60")
+	t.Setenv("RATE_LIMIT_ANONYMOUS_BURST", "1")
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(RateLimitMiddleware(initRateLimiters()))
+	r.GET("/rate-limit-metrics", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	before := testutil.ToFloat64(rateLimitHits.WithLabelValues("/rate-limit-metrics"))
+
+	for i := 0; i < 2; i++ {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/rate-limit-metrics", nil)
+		r.ServeHTTP(recorder, req)
+	}
+
+	after := testutil.ToFloat64(rateLimitHits.WithLabelValues("/rate-limit-metrics"))
+	require.Equal(t, float64(1), after-before)
+}
+
+func TestGatewayVerificationMetricRecordsInvalidResponses(t *testing.T) {
+	withVerifierResponse(t, http.StatusOK, `{"is_valid":false,"recovered_address":null,"error":"bad signature"}`)
+	router := newSummarizeTestRouter()
+
+	before := testutil.ToFloat64(verificationTotal.WithLabelValues("invalid"))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, signedSummarizeRequest(`{"text":"hello"}`))
+
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	after := testutil.ToFloat64(verificationTotal.WithLabelValues("invalid"))
+	require.Equal(t, float64(1), after-before)
+}
+
+func TestCacheMiddlewareRecordsHitsAndMisses(t *testing.T) {
+	origClient := redisClient
+	redisServer := miniredis.RunT(t)
+	redisClient = redis.NewClient(&redis.Options{Addr: redisServer.Addr()})
+	t.Cleanup(func() {
+		if redisClient != nil && redisClient != origClient {
+			_ = redisClient.Close()
+		}
+		redisClient = origClient
+	})
+
+	withVerifierResponse(t, http.StatusOK, `{"is_valid":false,"recovered_address":null,"error":"bad signature"}`)
+	router := newCachedSummarizeTestRouter()
+
+	missBefore := testutil.ToFloat64(cacheMisses.WithLabelValues("/api/ai/summarize"))
+	missRecorder := httptest.NewRecorder()
+	router.ServeHTTP(missRecorder, signedSummarizeRequest(`{"text":"cache miss metrics"}`))
+	require.Equal(t, http.StatusForbidden, missRecorder.Code)
+	missAfter := testutil.ToFloat64(cacheMisses.WithLabelValues("/api/ai/summarize"))
+	require.Equal(t, float64(1), missAfter-missBefore)
+
+	hitText := "cache hit metrics"
+	cachedBody := `{"result":"cached summary","cached_at":1700000000}`
+	cacheKey := getCacheKey(hitText, "z-ai/glm-4.5-air:free")
+	require.NoError(t, redisClient.Set(context.Background(), cacheKey, cachedBody, time.Hour).Err())
+
+	hitBefore := testutil.ToFloat64(cacheHits.WithLabelValues("/api/ai/summarize"))
+	hitRecorder := httptest.NewRecorder()
+	router.ServeHTTP(hitRecorder, signedSummarizeRequest(`{"text":"`+hitText+`"}`))
+	require.Equal(t, http.StatusForbidden, hitRecorder.Code)
+	hitAfter := testutil.ToFloat64(cacheHits.WithLabelValues("/api/ai/summarize"))
+	require.Equal(t, float64(1), hitAfter-hitBefore)
+}

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -129,6 +129,20 @@ func TestGatewayVerificationMetricRecordsInvalidResponses(t *testing.T) {
 	require.Equal(t, float64(1), after-before)
 }
 
+func TestGatewayVerificationMetricRecordsMalformedSuccessResponses(t *testing.T) {
+	withVerifierResponse(t, http.StatusOK, `{"is_valid":true,"recovered_address":"","error":""}`)
+	router := newSummarizeTestRouter()
+
+	before := testutil.ToFloat64(verificationTotal.WithLabelValues("error"))
+
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, signedSummarizeRequest(`{"text":"hello"}`))
+
+	require.Equal(t, http.StatusBadGateway, recorder.Code)
+	after := testutil.ToFloat64(verificationTotal.WithLabelValues("error"))
+	require.Equal(t, float64(1), after-before)
+}
+
 func TestCacheMiddlewareRecordsHitsAndMisses(t *testing.T) {
 	origClient := redisClient
 	redisServer := miniredis.RunT(t)

--- a/gateway/metrics_test.go
+++ b/gateway/metrics_test.go
@@ -39,6 +39,17 @@ func TestGetMetricsPathDefaultsAndNormalizesSlash(t *testing.T) {
 	require.Equal(t, "/custom-metrics", getMetricsPath())
 }
 
+func TestMetricsPathRejectsReservedRoutes(t *testing.T) {
+	require.NoError(t, validateMetricsPath("/metrics"))
+	require.NoError(t, validateMetricsPath("/internal/metrics"))
+
+	for _, path := range []string{"/healthz", "/readyz", "/docs", "/openapi.yaml", "/api/ai/summarize", "/api/receipts/:id"} {
+		t.Run(path, func(t *testing.T) {
+			require.Error(t, validateMetricsPath(path))
+		})
+	}
+}
+
 func TestMetricsMiddlewareRecordsTimeoutStatus(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -290,22 +290,29 @@ func MetricsMiddleware() gin.HandlerFunc {
 		}
 
 		activeRequests.Inc()
-		defer activeRequests.Dec()
+
+		defer func() {
+			statusCode := c.Writer.Status()
+			if recovered := recover(); recovered != nil {
+				if statusCode < http.StatusInternalServerError {
+					statusCode = http.StatusInternalServerError
+				}
+				recordRequestMetrics(c.Request.Method, path, statusCode, start)
+				activeRequests.Dec()
+				panic(recovered)
+			}
+
+			recordRequestMetrics(c.Request.Method, path, statusCode, start)
+			activeRequests.Dec()
+		}()
 
 		c.Next()
-
-		duration := time.Since(start).Seconds()
-		status := strconv.Itoa(c.Writer.Status())
-
-		requestsTotal.WithLabelValues(
-			c.Request.Method,
-			path,
-			status,
-		).Inc()
-
-		requestsDuration.WithLabelValues(
-			c.Request.Method,
-			path,
-		).Observe(duration)
 	}
+}
+
+func recordRequestMetrics(method, path string, statusCode int, start time.Time) {
+	status := strconv.Itoa(statusCode)
+
+	requestsTotal.WithLabelValues(method, path, status).Inc()
+	requestsDuration.WithLabelValues(method, path).Observe(time.Since(start).Seconds())
 }

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"sync"
 	"time"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -278,4 +279,32 @@ func (rws *responseWriterShim) CloseNotify() <-chan bool {
 	close(ch)
 	return ch
 
+}
+func MetricsMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path  := c.FullPath()
+		if path == "" {
+			path = "unknown"
+		}
+
+		activeRequests.Inc()
+		defer activeRequests.Dec()
+
+		c.Next()
+
+		duration := time.Since(start).Seconds()
+		status := strconv.Itoa(c.Writer.Status())
+
+		requestsTotal.WithLabelValues(
+			c.Request.Method,
+			path,
+			status,
+		).Inc()
+
+		requestsDuration.WithLabelValues(
+			c.Request.Method,
+			path,
+		).Observe(duration)
+	}
 }

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -216,10 +216,11 @@ func RequestTimeoutMiddleware(timeout time.Duration) gin.HandlerFunc {
 			// running handler may write directly to the real writer after the
 			// timeout response was already sent (causing panics or corruption).
 			bw.mu.Lock()
+			bw.status = http.StatusGatewayTimeout
 			bw.closed = true
 			bw.mu.Unlock()
 			origWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
-			origWriter.WriteHeader(504)
+			origWriter.WriteHeader(http.StatusGatewayTimeout)
 			_, _ = origWriter.Write([]byte(`{"error":"Gateway Timeout","message":"Request exceeded maximum allowed time"}`))
 			return
 		}
@@ -283,7 +284,7 @@ func (rws *responseWriterShim) CloseNotify() <-chan bool {
 func MetricsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
-		path  := c.FullPath()
+		path := c.FullPath()
 		if path == "" {
 			path = "unknown"
 		}

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -40,6 +40,22 @@ paths:
               schema:
                 $ref: "#/components/schemas/ReadyzResponse"
 
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      description: Exposes Prometheus text-format gateway metrics when METRICS_ENABLED is not false. The default path is /metrics and can be changed with METRICS_PATH.
+      responses:
+        "200":
+          description: Prometheus exposition text containing gateway request, latency, cache, verification, rate-limit, and in-flight metrics.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: |
+                  # HELP gateway_requests_total Total number of HTTP requests
+                  # TYPE gateway_requests_total counter
+                  gateway_requests_total{method="GET",path="/healthz",status="200"} 1
+
   /api/ai/summarize:
     post:
       summary: Summarize text with x402 payment enforcement

--- a/gateway/openapi_test.go
+++ b/gateway/openapi_test.go
@@ -26,13 +26,16 @@ func ginPathToOpenAPI(p string) string {
 }
 
 // TestOpenAPISpecMatchesRoutes enforces bidirectional alignment between the
-// API surface registered by registerAPIRoutes and the paths documented in
-// openapi.yaml. Documentation-meta routes (/docs, /openapi.yaml) live in
-// registerDocRoutes and are intentionally excluded from the API contract.
+// API surface registered by registerAPIRoutes, plus the default metrics route,
+// and the paths documented in openapi.yaml. Documentation-meta routes (/docs,
+// /openapi.yaml) live in registerDocRoutes and are intentionally excluded from
+// the API contract.
 func TestOpenAPISpecMatchesRoutes(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
+	t.Setenv("METRICS_PATH", "")
 	registerAPIRoutes(r)
+	r.GET(getMetricsPath(), func(c *gin.Context) {})
 
 	data, err := os.ReadFile(filepath.Join(".", "openapi.yaml"))
 	if err != nil {
@@ -61,7 +64,7 @@ func TestOpenAPISpecMatchesRoutes(t *testing.T) {
 	}
 
 	// Defense-in-depth: hard-require the four paths called out in issue #164.
-	required := []string{"/healthz", "/readyz", "/api/ai/summarize", "/api/receipts/{id}"}
+	required := []string{"/healthz", "/readyz", "/metrics", "/api/ai/summarize", "/api/receipts/{id}"}
 	for _, p := range required {
 		if _, ok := spec.Paths[p]; !ok {
 			t.Errorf("openapi.yaml is missing required path: %s", p)

--- a/verifier/Cargo.lock
+++ b/verifier/Cargo.lock
@@ -30,18 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,12 +37,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.101"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "arrayvec"
@@ -79,7 +61,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -107,7 +89,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -227,9 +209,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -264,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byte-slice-cast"
@@ -282,9 +264,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 dependencies = [
  "serde",
 ]
@@ -343,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -602,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -626,7 +608,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -691,7 +673,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -741,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.14.4"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
@@ -927,7 +909,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.114",
  "toml",
  "walkdir",
 ]
@@ -945,7 +927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -971,7 +953,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.116",
+ "syn 2.0.114",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -1110,6 +1092,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,9 +1154,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1174,12 +1167,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1214,9 +1201,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1229,9 +1216,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1239,15 +1226,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1256,9 +1243,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-locks"
@@ -1272,26 +1259,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -1305,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1317,6 +1304,7 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
+ "pin-utils",
  "slab",
 ]
 
@@ -1327,6 +1315,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1361,19 +1364,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1425,6 +1415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,20 +1428,11 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1621,11 +1608,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes",
+ "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
@@ -1716,12 +1704,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,7 +1759,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1794,8 +1776,6 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1887,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
@@ -1931,16 +1911,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
+name = "left-right"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
@@ -1948,7 +1933,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1980,6 +1965,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,27 +2004,28 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.18.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
 dependencies = [
  "base64 0.22.1",
+ "evmap",
  "indexmap",
  "metrics",
  "metrics-util",
@@ -2027,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.20.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2038,6 +2046,7 @@ dependencies = [
  "quanta",
  "rand 0.9.2",
  "rand_xoshiro",
+ "rapidhash",
  "sketches-ddsketch",
 ]
 
@@ -2073,6 +2082,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2137,7 +2155,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2202,7 +2220,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2332,7 +2350,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2361,7 +2379,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2435,7 +2453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2472,11 +2490,11 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2599,12 +2617,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2633,7 +2660,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -2649,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2661,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2672,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
@@ -2808,7 +2835,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2854,9 +2881,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "salsa20"
@@ -2897,8 +2924,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2991,7 +3024,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3072,6 +3105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,9 +3147,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.4"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -3123,9 +3165,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -3232,7 +3274,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3274,9 +3316,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3303,7 +3345,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3335,12 +3377,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3383,7 +3425,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3394,14 +3436,23 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
@@ -3420,9 +3471,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3487,7 +3538,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3586,9 +3637,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -3621,7 +3672,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.10.0",
  "bytes",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -3663,7 +3714,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3673,6 +3724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
 
 [[package]]
@@ -3683,6 +3735,35 @@ checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
  "pin-project",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3737,9 +3818,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.24"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -3792,6 +3873,12 @@ dependencies = [
  "getrandom 0.2.17",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "verifier"
@@ -3851,15 +3938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,7 +3983,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -3916,40 +3994,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -4004,6 +4048,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -4251,88 +4304,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.116",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -4393,28 +4364,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4434,7 +4405,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4474,7 +4445,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4499,9 +4470,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zstd"

--- a/verifier/Cargo.lock
+++ b/verifier/Cargo.lock
@@ -30,6 +30,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,11 +1381,26 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -1723,6 +1750,16 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1907,6 +1944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,6 +1973,61 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.32",
+ "indexmap 1.9.3",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -2176,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.13.0",
 ]
 
 [[package]]
@@ -2280,6 +2381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2471,22 @@ dependencies = [
  "rand_xorshift",
  "regex-syntax",
  "unarray",
+]
+
+[[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2453,6 +2576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2970,6 +3102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3544,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3420,7 +3558,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -3643,6 +3781,8 @@ dependencies = [
  "dashmap",
  "ethers",
  "hex",
+ "metrics",
+ "metrics-exporter-prometheus",
  "serde",
  "serde_json",
  "tokio",

--- a/verifier/Cargo.lock
+++ b/verifier/Cargo.lock
@@ -117,28 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,15 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,16 +479,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1248,12 +1207,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,25 +1425,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.4.0",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,7 +1570,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1660,7 +1594,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1670,7 +1603,6 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
- "want",
 ]
 
 [[package]]
@@ -1682,26 +1614,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "rustls 0.21.12",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
-dependencies = [
- "http 1.4.0",
- "hyper 1.8.1",
- "hyper-util",
- "rustls 0.23.36",
- "rustls-native-certs",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.26.4",
- "tower-service",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -1711,17 +1626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "futures-channel",
- "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
- "libc",
  "pin-project-lite",
- "socket2 0.6.2",
  "tokio",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2108,19 +2018,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
- "hyper-util",
  "indexmap",
- "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "rustls 0.23.36",
  "thiserror 2.0.18",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2268,12 +2170,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -2791,11 +2687,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls 0.24.2",
+ "hyper-rustls",
  "ipnet",
  "js-sys",
  "log",
@@ -2803,7 +2699,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.12",
+ "rustls",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2811,7 +2707,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2927,34 +2823,8 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.14",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
-dependencies = [
- "aws-lc-rs",
- "once_cell",
- "rustls-pki-types",
- "rustls-webpki 0.103.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -2967,33 +2837,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
-dependencies = [
- "zeroize",
-]
-
-[[package]]
 name = "rustls-webpki"
 version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring 0.17.14",
- "untrusted 0.9.0",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
-dependencies = [
- "aws-lc-rs",
- "ring 0.17.14",
- "rustls-pki-types",
  "untrusted 0.9.0",
 ]
 
@@ -3052,15 +2901,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,29 +2940,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -3496,7 +3313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 
@@ -3679,17 +3496,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.12",
- "tokio",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls 0.23.36",
+ "rustls",
  "tokio",
 ]
 
@@ -3701,9 +3508,9 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.12",
+ "rustls",
  "tokio",
- "tokio-rustls 0.24.1",
+ "tokio-rustls",
  "tungstenite",
  "webpki-roots",
 ]
@@ -3897,7 +3704,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.21.12",
+ "rustls",
  "sha1",
  "thiserror 1.0.69",
  "url",

--- a/verifier/Cargo.lock
+++ b/verifier/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -73,7 +79,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -101,7 +107,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -109,6 +115,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a7b350e3bb1767102698302bc37256cbd48422809984b98d292c40e2579aa9"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -181,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,9 +249,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitvec"
@@ -252,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
 
 [[package]]
 name = "byte-slice-cast"
@@ -270,9 +304,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -331,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -364,6 +398,15 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -467,6 +510,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -590,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -614,7 +667,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -679,7 +732,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -729,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "ena"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
 dependencies = [
  "log",
 ]
@@ -915,7 +968,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.116",
  "toml",
  "walkdir",
 ]
@@ -933,7 +986,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -959,7 +1012,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.114",
+ "syn 2.0.116",
  "tempfile",
  "thiserror 1.0.69",
  "tiny-keccak",
@@ -1149,9 +1202,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1162,6 +1215,18 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1183,6 +1248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,9 +1261,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1205,9 +1276,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1215,15 +1286,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1232,9 +1303,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-locks"
@@ -1248,26 +1319,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -1281,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1293,7 +1364,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1341,6 +1411,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1381,7 +1464,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1389,18 +1472,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "h2"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
- "ahash",
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1411,9 +1498,21 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashers"
@@ -1537,7 +1636,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1561,6 +1660,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -1570,6 +1670,7 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
 ]
 
 [[package]]
@@ -1581,25 +1682,46 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.8.1",
+ "hyper-util",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-channel",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
+ "libc",
  "pin-project-lite",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1684,6 +1806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,7 +1867,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -1750,22 +1878,14 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1857,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures",
 ]
@@ -1901,10 +2021,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libredox"
@@ -1912,7 +2038,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -1944,15 +2070,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "mach2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,62 +2087,55 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "metrics"
-version = "0.21.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
  "ahash",
- "metrics-macros",
  "portable-atomic",
 ]
 
 [[package]]
 name = "metrics-exporter-prometheus"
-version = "0.12.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4fa7ce7c4862db464a37b0b31d89bca874562f034bd7993895572783d02950"
+checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
- "base64 0.21.7",
- "hyper 0.14.32",
- "indexmap 1.9.3",
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "indexmap",
  "ipnet",
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror 1.0.69",
+ "rustls 0.23.36",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
-name = "metrics-macros"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "metrics-util"
-version = "0.15.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
- "hashbrown 0.13.1",
+ "hashbrown 0.16.1",
  "metrics",
- "num_cpus",
  "quanta",
+ "rand 0.9.2",
+ "rand_xoshiro",
  "sketches-ddsketch",
 ]
 
@@ -2125,7 +2235,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2160,6 +2270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,7 +2306,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2277,7 +2393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2320,7 +2436,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2349,7 +2465,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2423,7 +2539,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -2460,11 +2576,11 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -2475,13 +2591,12 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.11.1"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
 dependencies = [
  "crossbeam-utils",
  "libc",
- "mach2",
  "once_cell",
  "raw-cpuid",
  "wasi",
@@ -2579,12 +2694,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "raw-cpuid"
-version = "10.7.0"
+name = "rand_xoshiro"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "bitflags 1.3.2",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2613,7 +2737,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2629,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2641,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2652,9 +2776,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "reqwest"
@@ -2667,11 +2791,11 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -2679,7 +2803,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.12",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2687,7 +2811,7 @@ dependencies = [
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2788,7 +2912,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2803,8 +2927,34 @@ checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.14",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.103.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2814,6 +2964,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
 ]
 
 [[package]]
@@ -2827,6 +2986,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
+ "ring 0.17.14",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2834,9 +3005,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "salsa20"
@@ -2877,7 +3048,16 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2920,6 +3100,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321c8673b092a9a42605034a9879d73cb79101ed5fd117bc9a597b89b4e9e61a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2971,7 +3174,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3085,9 +3288,9 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -3103,9 +3306,9 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "sketches-ddsketch"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -3212,7 +3415,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3254,9 +3457,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3283,7 +3486,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3293,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -3315,12 +3518,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3363,7 +3566,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3374,14 +3577,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3400,9 +3603,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3467,7 +3670,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3476,7 +3679,17 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls",
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -3488,9 +3701,9 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.21.12",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tungstenite",
  "webpki-roots",
 ]
@@ -3544,7 +3757,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime 0.6.11",
@@ -3558,7 +3771,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
@@ -3566,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -3601,7 +3814,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -3643,7 +3856,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -3684,7 +3897,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls",
+ "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.69",
  "url",
@@ -3717,9 +3930,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -3831,6 +4044,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +4098,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
  "wasm-bindgen-shared",
 ]
 
@@ -3887,6 +4109,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -4188,6 +4444,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.116",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4248,28 +4586,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4289,7 +4627,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
  "synstructure",
 ]
 
@@ -4329,7 +4667,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.116",
 ]
 
 [[package]]
@@ -4354,9 +4692,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zstd"

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -10,6 +10,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ethers = "2.0"
 hex = "0.4"
+metrics = "0.21"
+metrics-exporter-prometheus = "0.12"
 # Combined tower entries into one line
 tower = { version = "0.5", features = ["util"] } 
 tower-http = { version = "0.6", features = ["limit"] }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -10,8 +10,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ethers = "2.0"
 hex = "0.4"
-metrics = "0.21"
-metrics-exporter-prometheus = "0.12"
+metrics = "0.24"
+metrics-exporter-prometheus = "0.18"
 # Combined tower entries into one line
 tower = { version = "0.5", features = ["util"] } 
 tower-http = { version = "0.6", features = ["limit"] }

--- a/verifier/Cargo.toml
+++ b/verifier/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1.0"
 ethers = "2.0"
 hex = "0.4"
 metrics = "0.24"
-metrics-exporter-prometheus = "0.18"
+metrics-exporter-prometheus = {version = "0.18", default-features = false }
 # Combined tower entries into one line
 tower = { version = "0.5", features = ["util"] } 
 tower-http = { version = "0.6", features = ["limit"] }

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -107,6 +107,10 @@ Important error codes:
 | `timestamp_missing` | Timestamp field is missing or invalid. |
 | `nonce_already_used` | Nonce hash was already accepted inside the signature window. |
 
+### `GET /metrics`
+
+Returns Prometheus text-format metrics for verifier request volume, verification latency, valid signatures, and invalid signatures by rejection reason.
+
 ## Configuration
 
 | Variable | Default | Notes |
@@ -131,6 +135,20 @@ cargo run
 ```
 
 The service listens on `0.0.0.0:3002` by default.
+
+## Metrics
+
+The verifier exposes Prometheus metrics at `GET /metrics` on port `3002`.
+
+Example local scrape config:
+
+```yaml
+scrape_configs:
+  - job_name: microai-verifier
+    static_configs:
+      - targets: ["localhost:3002"]
+    metrics_path: /metrics
+```
 
 ## Testing
 

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -121,7 +121,6 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
-
 }
 
 async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -9,7 +9,12 @@ use axum::{
 use dashmap::{mapref::entry::Entry, DashMap};
 use ethers::types::transaction::eip712::TypedData;
 use ethers::types::Signature;
+
 use ethers::utils::keccak256;
+
+mod metrics;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::net::SocketAddr;
@@ -108,7 +113,21 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
+
+    let recorder = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install recorder");
+
+    let metrics_route = {
+        let handle = recorder.clone();
+        move || async move {handle.render() }
+    };
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/verify", post(verify_signature))
+        .route("/metrics", get(metrics_route));
 }
+
 
 async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
     let (_, res_headers) = correlation_id_headers(&headers);
@@ -435,6 +454,7 @@ async fn verify_signature(
         }
     };
 
+
     match sig.recover_typed_data(&typed_data) {
         Ok(addr) => {
             if !claim_nonce(&state, &payload.context.nonce, Instant::now()) {
@@ -461,9 +481,22 @@ async fn verify_signature(
                 }),
             )
         }
+
+    let start = std::time::Instant::now();
+    let (status,headers,Json(response)) = match sig.recover_typed_data(&typed_data) {
+        Ok(addr) => (
+            StatusCode::OK,
+            res_headers.clone(),
+            Json(VerifyResponse {
+                is_valid: true,
+                recovered_address: Some(format!("{:?}", addr)),
+                error: None,
+            }),
+        ),
+
         Err(e) => (
             StatusCode::OK,
-            res_headers,
+            res_headers.clone(),
             Json(VerifyResponse {
                 is_valid: false,
                 recovered_address: None,
@@ -471,7 +504,12 @@ async fn verify_signature(
                 error_code: Some("invalid_signature".to_string()),
             }),
         ),
-    }
+    };
+    
+    let duration = start.elapsed().as_secs_f64();
+    metrics::record_verification(response.is_valid, duration, response.error.as_deref());
+    (status, res_headers, Json(response),)
+    
 }
 
 /* =======================

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -13,7 +13,7 @@ use ethers::types::Signature;
 use ethers::utils::keccak256;
 
 mod metrics;
-
+use ::metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 
 use serde::{Deserialize, Serialize};
@@ -306,6 +306,8 @@ async fn verify_signature(
     // 1. Get correlation ID headers first so we can use them in error responses
     let (cid, res_headers) = correlation_id_headers(&headers);
 
+    counter!("verifier_requests_total").increment(1);
+
     // 2. Security Check: Match the payload result immediately
     let payload = match payload {
         Ok(Json(p)) => p, // Everything is good, proceed with payload 'p'
@@ -454,7 +456,7 @@ async fn verify_signature(
     let duration = start.elapsed().as_secs_f64();
 
     match result {
-        Ok(_addr) => {
+        Ok(addr) => {
             if !claim_nonce(&state, &payload.context.nonce, Instant::now()) {
                 metrics::record_verification(false, duration, Some("nonce_already_used"));
                 return (
@@ -462,7 +464,7 @@ async fn verify_signature(
                     res_headers,
                     Json(VerifyResponse {
                         is_valid: false,
-                        recovered_address: None,
+                        recovered_address: Some(format!("{:?}", addr)),
                         error: Some("nonce already used".to_string()),
                         error_code: Some("nonce_already_used".to_string()),
                     }),
@@ -474,7 +476,7 @@ async fn verify_signature(
                 res_headers,
                 Json(VerifyResponse {
                     is_valid: true,
-                    recovered_address: None,
+                    recovered_address: Some(format!("{:?}", addr)),
                     error: None,
                     error_code: None,
                 }),

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -448,10 +448,15 @@ async fn verify_signature(
         }
     };
 
+    let start = std::time::Instant::now();
 
-    match sig.recover_typed_data(&typed_data) {
-        Ok(addr) => {
+    let result = sig.recover_typed_data(&typed_data);
+    let duration = start.elapsed().as_secs_f64();
+
+    match result {
+        Ok(_addr) => {
             if !claim_nonce(&state, &payload.context.nonce, Instant::now()) {
+                metrics::record_verification(false, duration, Some("nonce_already_used"));
                 return (
                     StatusCode::CONFLICT,
                     res_headers,
@@ -463,46 +468,32 @@ async fn verify_signature(
                     }),
                 );
             }
-
+            metrics::record_verification(true, duration, None);
             (
                 StatusCode::OK,
                 res_headers,
                 Json(VerifyResponse {
                     is_valid: true,
-                    recovered_address: Some(format!("{:?}", addr)),
+                    recovered_address: None,
                     error: None,
                     error_code: None,
                 }),
             )
         }
-
-    let start = std::time::Instant::now();
-    let (status, _, Json(response)) = match sig.recover_typed_data(&typed_data) {
-        Ok(addr) => (
-            StatusCode::OK,
-            res_headers.clone(),
-            Json(VerifyResponse {
-                is_valid: true,
-                recovered_address: Some(format!("{:?}", addr)),
-                error: None,
-            }),
-        ),
-
-        Err(e) => (
-            StatusCode::OK,
-            res_headers.clone(),
-            Json(VerifyResponse {
-                is_valid: false,
-                recovered_address: None,
-                error: Some(e.to_string()),
-                error_code: Some("invalid_signature".to_string()),
-            }),
-        ),
-    };
-
-    let duration = start.elapsed().as_secs_f64();
-    metrics::record_verification(response.is_valid, duration, response.error.as_deref());
-    (status, res_headers, Json(response))
+        Err(e) => {
+            metrics::record_verification(false, duration, Some("invalid_signature"));
+            (
+                StatusCode::OK,
+                res_headers,
+                Json(VerifyResponse {
+                    is_valid: false,
+                    recovered_address: None,
+                    error: Some(e.to_string()),
+                    error_code: Some("invalid_signature".to_string()),
+                }),
+            )
+        }
+    }
 }
 
 /* =======================

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -102,9 +102,18 @@ async fn main() {
         signature_expiry_seconds: get_env_u64("SIGNATURE_EXPIRY_SECONDS", 300),
         clock_skew_seconds: get_env_u64("SIGNATURE_CLOCK_SKEW_SECONDS", 60),
     };
+    let recorder = PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install recorder");
+
+    let metrics_handle = recorder.clone();
+    let metrics_route = {
+        let handle = move || async move { metrics_handle.render() };
+    };
     let app = Router::new()
         .route("/health", get(health))
         .route("/verify", post(verify_signature))
+        .route("/metrics", get(metrics_route))
         .layer(DefaultBodyLimit::max(limit))
         .with_state(state);
 
@@ -114,20 +123,11 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 
-    let recorder = PrometheusBuilder::new()
-        .install_recorder()
-        .expect("failed to install recorder");
-
-    let metrics_route = {
-        let handle = recorder.clone();
-        move || async move {handle.render() }
-    };
     let app = Router::new()
         .route("/health", get(health))
         .route("/verify", post(verify_signature))
         .route("/metrics", get(metrics_route));
 }
-
 
 async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
     let (_, res_headers) = correlation_id_headers(&headers);
@@ -483,7 +483,7 @@ async fn verify_signature(
         }
 
     let start = std::time::Instant::now();
-    let (status,headers,Json(response)) = match sig.recover_typed_data(&typed_data) {
+    let (status, headers, Json(response)) = match sig.recover_typed_data(&typed_data) {
         Ok(addr) => (
             StatusCode::OK,
             res_headers.clone(),
@@ -505,11 +505,10 @@ async fn verify_signature(
             }),
         ),
     };
-    
+
     let duration = start.elapsed().as_secs_f64();
     metrics::record_verification(response.is_valid, duration, response.error.as_deref());
-    (status, res_headers, Json(response),)
-    
+    (status, res_headers, Json(response))
 }
 
 /* =======================

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -13,7 +13,8 @@ use ethers::types::Signature;
 use ethers::utils::keccak256;
 
 mod metrics;
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+use metrics_exporter_prometheus::PrometheusBuilder;
 
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -106,10 +107,8 @@ async fn main() {
         .install_recorder()
         .expect("failed to install recorder");
 
-    let metrics_handle = recorder.clone();
-    let metrics_route = {
-        let handle = move || async move { metrics_handle.render() };
-    };
+    let metrics_route = move || async move { recorder.render() };
+
     let app = Router::new()
         .route("/health", get(health))
         .route("/verify", post(verify_signature))
@@ -123,10 +122,6 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 
-    let app = Router::new()
-        .route("/health", get(health))
-        .route("/verify", post(verify_signature))
-        .route("/metrics", get(metrics_route));
 }
 
 async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
@@ -483,7 +478,7 @@ async fn verify_signature(
         }
 
     let start = std::time::Instant::now();
-    let (status, headers, Json(response)) = match sig.recover_typed_data(&typed_data) {
+    let (status, _, Json(response)) = match sig.recover_typed_data(&typed_data) {
         Ok(addr) => (
             StatusCode::OK,
             res_headers.clone(),

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -14,7 +14,7 @@ use ethers::utils::keccak256;
 
 mod metrics;
 
-use metrics_exporter_prometheus::PrometheusBuilder;
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -106,13 +106,12 @@ async fn main() {
     let recorder = PrometheusBuilder::new()
         .install_recorder()
         .expect("failed to install recorder");
-
-    let metrics_route = move || async move { recorder.render() };
+    spawn_metrics_upkeep(recorder.clone());
 
     let app = Router::new()
         .route("/health", get(health))
         .route("/verify", post(verify_signature))
-        .route("/metrics", get(metrics_route))
+        .route("/metrics", get(metrics_route(recorder)))
         .layer(DefaultBodyLimit::max(limit))
         .with_state(state);
 
@@ -121,6 +120,22 @@ async fn main() {
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
+}
+
+fn metrics_route(
+    handle: PrometheusHandle,
+) -> impl Fn() -> std::future::Ready<String> + Clone + Send + Sync + 'static {
+    move || std::future::ready(handle.clone().render())
+}
+
+fn spawn_metrics_upkeep(handle: PrometheusHandle) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            handle.run_upkeep();
+        }
+    });
 }
 
 async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
@@ -309,16 +324,13 @@ async fn verify_signature(
     let request_start = std::time::Instant::now();
     ::metrics::counter!("verifier_requests_total").increment(1);
 
-    //::metrics::counter!("verifier_requests_total").increment(1);
-
     // 2. Security Check: Match the payload result immediately
     let payload = match payload {
         Ok(Json(p)) => p, // Everything is good, proceed with payload 'p'
         Err(JsonRejection::BytesRejection(_)) => {
             println!("[CID: {}] Rejected: Payload too large", cid);
 
-            let duration = request_start.elapsed().as_secs_f64();
-            metrics::record_verification(false, duration, Some("payload_too_large"));
+            record_verification_failure(&request_start, "payload_too_large");
 
             return (
                 StatusCode::PAYLOAD_TOO_LARGE,
@@ -337,8 +349,7 @@ async fn verify_signature(
         Err(e) => {
             println!("[CID: {}] Rejected: Invalid JSON or formatting", cid);
 
-            let duration = request_start.elapsed().as_secs_f64();
-            metrics::record_verification(false, duration, Some("payload_too_large"));
+            record_verification_failure(&request_start, "invalid_json");
 
             return (
                 StatusCode::BAD_REQUEST,
@@ -357,8 +368,7 @@ async fn verify_signature(
     println!("[CID: {}] Verify nonce={}", cid, payload.context.nonce);
 
     if payload.context.chain_id != state.expected_chain_id {
-        let duration = request_start.elapsed().as_secs_f64();
-        metrics::record_verification(false, duration, Some("payload_too_large"));
+        record_verification_failure(&request_start, "chain_id_mismatch");
 
         return (
             StatusCode::BAD_REQUEST,
@@ -394,8 +404,7 @@ async fn verify_signature(
             }
         };
 
-        let duration = request_start.elapsed().as_secs_f64();
-        metrics::record_verification(false, duration, Some("payload_too_large"));
+        record_verification_failure(&request_start, error_code);
 
         return (
             StatusCode::OK,
@@ -438,6 +447,7 @@ async fn verify_signature(
     let typed_data: TypedData = match serde_json::from_value(typed_data_json) {
         Ok(td) => td,
         Err(e) => {
+            record_verification_failure(&request_start, "typed_data_error");
             return (
                 StatusCode::BAD_REQUEST,
                 res_headers,
@@ -454,6 +464,7 @@ async fn verify_signature(
     let sig = match Signature::from_str(&payload.signature) {
         Ok(s) => s,
         Err(e) => {
+            record_verification_failure(&request_start, "invalid_signature");
             return (
                 StatusCode::BAD_REQUEST,
                 res_headers,
@@ -513,6 +524,10 @@ async fn verify_signature(
             )
         }
     }
+}
+
+fn record_verification_failure(request_start: &Instant, reason: &'static str) {
+    metrics::record_verification(false, request_start.elapsed().as_secs_f64(), Some(reason));
 }
 
 /* =======================
@@ -1237,5 +1252,96 @@ mod tests {
         // 4. Verify the results
         assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE); // 413
         assert!(response.headers().contains_key("x-correlation-id")); // Header check
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_verify_signature_records_specific_failure_reasons() {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let _guard = ::metrics::set_default_local_recorder(&recorder);
+
+        let wrong_chain = signed_request("metrics-wrong-chain", 1, now()).await;
+        let (status, _, Json(resp)) =
+            verify_signature(State(app_state()), HeaderMap::new(), Ok(Json(wrong_chain))).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(resp.error_code.as_deref(), Some("chain_id_mismatch"));
+
+        let missing_timestamp = VerifyRequest {
+            context: PaymentContext {
+                recipient: "0x1234567890123456789012345678901234567890".to_string(),
+                token: "USDC".to_string(),
+                amount: "100".to_string(),
+                nonce: "metrics-missing-timestamp".to_string(),
+                chain_id: BASE_SEPOLIA_CHAIN_ID,
+                timestamp: None,
+            },
+            signature: "0x1234567890".to_string(),
+        };
+        let (status, _, Json(resp)) = verify_signature(
+            State(app_state()),
+            HeaderMap::new(),
+            Ok(Json(missing_timestamp)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(resp.error_code.as_deref(), Some("timestamp_missing"));
+
+        let malformed_signature = VerifyRequest {
+            context: PaymentContext {
+                recipient: "0x1234567890123456789012345678901234567890".to_string(),
+                token: "USDC".to_string(),
+                amount: "100".to_string(),
+                nonce: "metrics-malformed-signature".to_string(),
+                chain_id: BASE_SEPOLIA_CHAIN_ID,
+                timestamp: Some(now()),
+            },
+            signature: "not-a-signature".to_string(),
+        };
+        let (status, _, Json(resp)) = verify_signature(
+            State(app_state()),
+            HeaderMap::new(),
+            Ok(Json(malformed_signature)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(resp.error_code.as_deref(), Some("invalid_signature"));
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains("verifier_signature_invalid_total{reason=\"chain_id_mismatch\"} 1")
+        );
+        assert!(
+            rendered.contains("verifier_signature_invalid_total{reason=\"timestamp_missing\"} 1")
+        );
+        assert!(
+            rendered.contains("verifier_signature_invalid_total{reason=\"invalid_signature\"} 1")
+        );
+        assert!(
+            !rendered.contains("verifier_signature_invalid_total{reason=\"payload_too_large\"}")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_metrics_route_can_be_scraped_repeatedly() {
+        use axum::{body::Body, http::Request};
+        use tower::ServiceExt;
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let app = Router::new().route("/metrics", get(metrics_route(recorder.handle())));
+
+        for _ in 0..2 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method("GET")
+                        .uri("/metrics")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
     }
 }

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -13,7 +13,7 @@ use ethers::types::Signature;
 use ethers::utils::keccak256;
 
 mod metrics;
-use ::metrics::counter;
+
 use metrics_exporter_prometheus::PrometheusBuilder;
 
 use serde::{Deserialize, Serialize};
@@ -309,13 +309,17 @@ async fn verify_signature(
     let request_start = std::time::Instant::now();
     ::metrics::counter!("verifier_requests_total").increment(1);
 
-    counter!("verifier_requests_total").increment(1);
+    //::metrics::counter!("verifier_requests_total").increment(1);
 
     // 2. Security Check: Match the payload result immediately
     let payload = match payload {
         Ok(Json(p)) => p, // Everything is good, proceed with payload 'p'
         Err(JsonRejection::BytesRejection(_)) => {
             println!("[CID: {}] Rejected: Payload too large", cid);
+
+            let duration = request_start.elapsed().as_secs_f64();
+            metrics::record_verification(false, duration, Some("payload_too_large"));
+
             return (
                 StatusCode::PAYLOAD_TOO_LARGE,
                 res_headers,
@@ -332,6 +336,10 @@ async fn verify_signature(
         }
         Err(e) => {
             println!("[CID: {}] Rejected: Invalid JSON or formatting", cid);
+
+            let duration = request_start.elapsed().as_secs_f64();
+            metrics::record_verification(false, duration, Some("payload_too_large"));
+
             return (
                 StatusCode::BAD_REQUEST,
                 res_headers,
@@ -349,6 +357,9 @@ async fn verify_signature(
     println!("[CID: {}] Verify nonce={}", cid, payload.context.nonce);
 
     if payload.context.chain_id != state.expected_chain_id {
+        let duration = request_start.elapsed().as_secs_f64();
+        metrics::record_verification(false, duration, Some("payload_too_large"));
+
         return (
             StatusCode::BAD_REQUEST,
             res_headers,
@@ -382,6 +393,9 @@ async fn verify_signature(
                 ("E009: missing timestamp".to_string(), "timestamp_missing")
             }
         };
+
+        let duration = request_start.elapsed().as_secs_f64();
+        metrics::record_verification(false, duration, Some("payload_too_large"));
 
         return (
             StatusCode::OK,

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -306,6 +306,9 @@ async fn verify_signature(
     // 1. Get correlation ID headers first so we can use them in error responses
     let (cid, res_headers) = correlation_id_headers(&headers);
 
+    let request_start = std::time::Instant::now();
+    ::metrics::counter!("verifier_requests_total").increment(1);
+
     counter!("verifier_requests_total").increment(1);
 
     // 2. Security Check: Match the payload result immediately
@@ -450,10 +453,10 @@ async fn verify_signature(
         }
     };
 
-    let start = std::time::Instant::now();
+    //let start = std::time::Instant::now();
 
     let result = sig.recover_typed_data(&typed_data);
-    let duration = start.elapsed().as_secs_f64();
+    let duration = request_start.elapsed().as_secs_f64();
 
     match result {
         Ok(addr) => {

--- a/verifier/src/metrics.rs
+++ b/verifier/src/metrics.rs
@@ -1,7 +1,6 @@
 use metrics::{counter, histogram};
 
 pub fn record_verification(valid: bool, duration: f64, reason: Option<&str>) {
-    //counter!("verifier_requests_total").increment(1);
     histogram!("verifier_request_duration_seconds").record(duration);
 
     if valid {

--- a/verifier/src/metrics.rs
+++ b/verifier/src/metrics.rs
@@ -1,7 +1,7 @@
 use metrics::{counter, histogram};
 
 pub fn record_verification(valid: bool, duration: f64, reason: Option<&str>) {
-    counter!("verifier_requests_total").increment(1);
+    //counter!("verifier_requests_total").increment(1);
     histogram!("verifier_request_duration_seconds").record(duration);
 
     if valid {

--- a/verifier/src/metrics.rs
+++ b/verifier/src/metrics.rs
@@ -1,17 +1,17 @@
 use metrics::{counter, histogram};
 
-pub fn record_verification(valid: bool, duration: f64, reason: Option<&str>){
-    counter!("verifier_requests_total", 1);
-    histogram!("verifier_request_duration_seconds", duration);
+pub fn record_verification(valid: bool, duration: f64, reason: Option<&str>) {
+    counter!("verifier_requests_total").increment(1);
+    histogram!("verifier_request_duration_seconds").record(duration);
 
     if valid {
-        counter!("verifier_signature_valid_total", 1);
+        counter!("verifier_signature_valid_total").increment(1);
     } else {
         let label = reason.unwrap_or("unknown").to_string();
         counter!(
             "verifier_signature_invalid_total",
-            1,
             "reason" => label
-        );
+        )
+        .increment(1);
     }
 }

--- a/verifier/src/metrics.rs
+++ b/verifier/src/metrics.rs
@@ -1,0 +1,17 @@
+use metrics::{counter, histogram};
+
+pub fn record_verification(valid: bool, duration: f64, reason: Option<&str>){
+    counter!("verifier_requests_total", 1);
+    histogram!("verifier_request_duration_seconds", duration);
+
+    if valid {
+        counter!("verifier_signature_valid_total", 1);
+    } else {
+        let label = reason.unwrap_or("unknown").to_string();
+        counter!(
+            "verifier_signature_invalid_total",
+            1,
+            "reason" => label
+        );
+    }
+}


### PR DESCRIPTION
Fixes: #79 

Added Prometheus ` /metrics` endpoint at Gateway and Verifier

Checked testing for Gateway and Verifier Metrics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Prometheus metrics and an optional /metrics endpoint to monitor requests, latencies, active requests, cache hits/misses, rate limits, and verification outcomes.

* **Bug Fixes / Behavior**
  * Records route-specific cache hit/miss and verification metrics; verification failures now increment failure metrics and can alter responses (deadline, validation, or authorization errors).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Prometheus metrics instrumentation to both the Go gateway and the Rust verifier services. The gateway implementation defines counters for requests, cache hits/misses, rate limits, and verification results, plus a histogram for request duration and a gauge for active requests. The verifier adds per-verification metrics tracking. However, the PR has several critical bugs that prevent it from working as intended:

- **Verifier metrics are completely non-functional**: The Prometheus recorder setup and `/metrics` route are placed *after* the blocking `axum::serve()` call, making them unreachable dead code. The recorder is never installed, so `metrics::record_verification()` calls silently no-op, and the `/metrics` endpoint is never served.
- **Verifier `metrics.rs` uses the wrong macro API**: The `metrics` crate v0.21 changed its macro syntax. The old `counter!("name", 1)` form from v0.17–0.20 was removed; v0.21 requires `counter!("name").increment(1)`. This code will fail to compile.
- **Gateway cache miss counter is wrong**: The cache MISS path increments the `cacheHits` counter instead of `cacheMisses`, making both metrics inaccurate.
- **Duplicate middleware registration**: `CorrelationIDMiddleware()` is registered twice on the router, causing every request to run through it twice.

<h3>Confidence Score: 1/5</h3>

- This PR has multiple critical bugs — the verifier metrics will not compile and the gateway has logic errors in metric counters and middleware ordering.
- Score of 1 reflects: (1) verifier metrics.rs uses incorrect API for metrics 0.21 and will not compile, (2) all verifier Prometheus setup is unreachable dead code after a blocking serve call, (3) gateway cache miss incorrectly increments cache hit counter, (4) duplicate CorrelationIDMiddleware registration. The gateway MetricsMiddleware and metrics definitions are structurally sound, but the bugs above make the PR unsafe to merge without fixes.
- Pay close attention to `verifier/src/main.rs` (dead code after serve), `verifier/src/metrics.rs` (wrong API), `gateway/cache.go` (wrong counter), and `gateway/main.go` (duplicate middleware).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/main.go | Duplicate CorrelationIDMiddleware registration causes double execution; MetricsMiddleware added before existing middleware ordering; leftover commented-out code at end of file. |
| gateway/cache.go | Cache miss path incorrectly increments cacheHits counter instead of cacheMisses — metrics data will be wrong for both hit and miss counts. |
| gateway/metrics.go | New file defining Prometheus metrics; rateLimitHits and verificationTotal are declared but never used anywhere in the codebase. |
| gateway/middleware.go | MetricsMiddleware implementation is correct — tracks active requests, request counts, and duration histograms with proper label usage. |
| gateway/go.mod | Adds prometheus/client_golang and transitive dependencies; versions appear appropriate. |
| verifier/src/main.rs | Critical: All Prometheus setup code is unreachable (placed after blocking axum::serve call). The /metrics endpoint will never be served and the recorder is never installed. |
| verifier/src/metrics.rs | Uses metrics crate 0.21 macros with the old v0.17-0.20 syntax (counter!("name", 1)) which was removed in 0.21 — this will not compile. |
| verifier/Cargo.toml | Adds metrics 0.21 and metrics-exporter-prometheus 0.12 — versions are compatible with each other. |

</details>



<h3>Flowchart</h3>

```mermaid
flowchart TD
    A[Incoming HTTP Request] --> B[CorrelationIDMiddleware]
    B --> C{METRICS_ENABLED != false?}
    C -->|Yes| D[MetricsMiddleware]
    C -->|No| E[CORS / Rate Limit / Timeout]
    D --> E
    E --> F{Route}
    F -->|/metrics| G[promhttp.Handler - Prometheus Scrape]
    F -->|/api/ai/summarize| H{Cache Enabled?}
    H -->|Yes| I[CacheMiddleware]
    H -->|No| J[handleSummarize]
    I -->|Cache HIT| K[cacheHits.Inc]
    I -->|Cache MISS| L["⚠️ BUG: cacheHits.Inc instead of cacheMisses.Inc"]
    K --> M[Verify Payment & Serve Cached]
    L --> J
    J --> N[Verify Payment → Verifier Service]
    N --> O[Verifier /verify]
    O --> P["metrics::record_verification()"]
    P --> Q["⚠️ BUG: No recorder installed - silently no-ops"]
    F -->|/health /readyz| R[Health Check Handlers]
```

<sub>Last reviewed commit: 46836ba</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

**Context used:**

- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))

<!-- /greptile_comment -->