### PR TITLE
fix: use IP-based rate limiting to prevent infinite bucket attacks[ISSUE #100]

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -204,6 +204,20 @@ func main() {
 
 	r := gin.Default()
 
+	// Restrict trusted proxies to prevent X-Forwarded-For spoofing.
+	// IP-based rate limiting relies on c.ClientIP(), which reads
+	// X-Forwarded-For only from proxies in this list. An empty list
+	// means only the direct remote address is trusted.
+	// Set TRUSTED_PROXIES env var (comma-separated CIDRs) for production.
+	if trustedProxies := getTrustedProxies(); len(trustedProxies) > 0 {
+		if err := r.SetTrustedProxies(trustedProxies); err != nil {
+			log.Printf("[WARN] invalid TRUSTED_PROXIES value: %v", err)
+		}
+	} else {
+		// Trust no proxies: always use direct RemoteAddr for ClientIP.
+		_ = r.SetTrustedProxies(nil)
+	}
+
 	// VIBE FIX: Register the Correlation ID Middleware immediately
 	// This ensures every single request gets an ID before anything else happens.
 	r.Use(CorrelationIDMiddleware())
@@ -778,6 +792,24 @@ func getLimitForTier(tier string) int {
 func getRateLimitEnabled() bool {
 	enabled := strings.ToLower(os.Getenv("RATE_LIMIT_ENABLED"))
 	return enabled == "true" || enabled == "1"
+}
+
+// getTrustedProxies returns the list of trusted proxy CIDRs/IPs from the
+// TRUSTED_PROXIES environment variable (comma-separated). Returns nil when
+// the variable is unset so the caller can disable proxy trust entirely.
+func getTrustedProxies() []string {
+	raw := strings.TrimSpace(os.Getenv("TRUSTED_PROXIES"))
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	trusted := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			trusted = append(trusted, trimmed)
+		}
+	}
+	return trusted
 }
 
 // getEnvAsInt retrieves an environment variable as an integer with a default value

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdsa"
-	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -233,7 +233,8 @@ func main() {
 	// Set TRUSTED_PROXIES env var (comma-separated CIDRs) for production.
 	if trustedProxies := getTrustedProxies(); len(trustedProxies) > 0 {
 		if err := r.SetTrustedProxies(trustedProxies); err != nil {
-			log.Printf("[WARN] invalid TRUSTED_PROXIES value: %v", err)
+			_ = r.SetTrustedProxies(nil)
+			log.Printf("[WARN] invalid TRUSTED_PROXIES value, falling back to no trusted proxies: %v", err)
 		}
 	} else {
 		// Trust no proxies: always use direct RemoteAddr for ClientIP.

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -724,19 +724,12 @@ func RateLimitMiddleware(limiters map[string]RateLimiter) gin.HandlerFunc {
 	}
 }
 
-// getRateLimitKey determines the key for rate limiting (nonce/wallet > IP)
+// getRateLimitKey determines the key for rate limiting (always uses IP)
 func getRateLimitKey(c *gin.Context) string {
-	signature := c.GetHeader("X-402-Signature")
-	nonce := c.GetHeader("X-402-Nonce")
-
-	// Only use nonce-based key if BOTH signature and nonce are present
-	// This prevents attackers from bypassing IP rate limits with fake nonces
-	if signature != "" && nonce != "" {
-		hash := sha256.Sum256([]byte(nonce))
-		// Use 32 hex chars (128 bits) for better collision resistance
-		return "nonce:" + hex.EncodeToString(hash[:])[:32]
-	}
-
+	// REMOVED: Nonce-based keying
+	// Nonces must be unique per request (replay attack prevention),
+	// which creates infinite buckets and memory leaks.
+	// ALWAYS use IP for now to prevent infinite-bucket attacks
 	return "ip:" + c.ClientIP()
 }
 

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -246,7 +246,7 @@ func TestGetRateLimitKey(t *testing.T) {
 		nonce       string
 		expectedKey string
 	}{
-		{"With both signature and nonce", "sig123", "test-nonce", "nonce:"},
+		{"With both signature and nonce", "sig123", "test-nonce", "ip:"},
 		{"Only nonce (no signature)", "", "test-nonce", "ip:"},
 		{"Only signature (no nonce)", "sig123", "", "ip:"},
 		{"Neither", "", "", "ip:"},
@@ -258,18 +258,10 @@ func TestGetRateLimitKey(t *testing.T) {
 			r.GET("/test", func(c *gin.Context) {
 				key := getRateLimitKey(c)
 
-				if strings.HasPrefix(tt.expectedKey, "nonce:") {
-					if !strings.HasPrefix(key, "nonce:") {
-						t.Errorf("Expected nonce-based key, got '%s'", key)
-					}
-					hashPart := strings.TrimPrefix(key, "nonce:")
-					if len(hashPart) != 32 {
-						t.Errorf("Expected hash to be 32 chars, got %d", len(hashPart))
-					}
-				} else {
-					if !strings.HasPrefix(key, "ip:") {
-						t.Errorf("Expected IP-based key, got '%s'", key)
-					}
+				// After fix: All keys should be IP-based to prevent
+				// infinite bucket attacks from unique nonces
+				if !strings.HasPrefix(key, "ip:") {
+					t.Errorf("Expected IP-based key, got '%s'", key)
 				}
 				c.JSON(200, gin.H{"key": key})
 			})

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -246,10 +246,10 @@ func TestGetRateLimitKey(t *testing.T) {
 		nonce       string
 		expectedKey string
 	}{
-		{"With both signature and nonce", "sig123", "test-nonce", "ip:"},
-		{"Only nonce (no signature)", "", "test-nonce", "ip:"},
-		{"Only signature (no nonce)", "sig123", "", "ip:"},
-		{"Neither", "", "", "ip:"},
+		{"IP-based rate limiting (with signature and nonce)", "sig123", "test-nonce", "ip:"},
+		{"IP-based rate limiting (with nonce only)", "", "test-nonce", "ip:"},
+		{"IP-based rate limiting (with signature only)", "sig123", "", "ip:"},
+		{"IP-based rate limiting (without auth headers)", "", "", "ip:"},
 	}
 
 	for _, tt := range tests {

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -179,6 +179,7 @@ func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
 		req, _ := http.NewRequest("GET", "/test", nil)
 		req.Header.Set("X-402-Signature", "sig1")
 		req.Header.Set("X-402-Nonce", "user1-11111111") // Different first 8 chars
+		req.RemoteAddr = "192.168.1.1:12345"            // Explicit IP for User 1
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		if w.Code != 200 {
@@ -190,6 +191,7 @@ func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
 	req1, _ := http.NewRequest("GET", "/test", nil)
 	req1.Header.Set("X-402-Signature", "sig1")
 	req1.Header.Set("X-402-Nonce", "user1-11111111")
+	req1.RemoteAddr = "192.168.1.1:12345" // Same IP as User 1
 	w1 := httptest.NewRecorder()
 	r.ServeHTTP(w1, req1)
 	if w1.Code != 429 {
@@ -200,6 +202,7 @@ func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
 	req2, _ := http.NewRequest("GET", "/test", nil)
 	req2.Header.Set("X-402-Signature", "sig2")
 	req2.Header.Set("X-402-Nonce", "user2-22222222") // Different first 8 chars
+	req2.RemoteAddr = "192.168.1.2:12345"            // Different IP for User 2
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	if w2.Code != 200 {

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -155,7 +155,7 @@ func TestRateLimitMiddleware_StandardUser(t *testing.T) {
 }
 
 func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
-	// Verify that different users have separate rate limit buckets
+	// Verify that different IPs have separate rate limit buckets
 	os.Setenv("RATE_LIMIT_ENABLED", "true")
 	os.Setenv("RATE_LIMIT_STANDARD_RPM", "60")
 	os.Setenv("RATE_LIMIT_STANDARD_BURST", "2")
@@ -178,8 +178,8 @@ func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
 	for i := 0; i < 2; i++ {
 		req, _ := http.NewRequest("GET", "/test", nil)
 		req.Header.Set("X-402-Signature", "sig1")
-		req.Header.Set("X-402-Nonce", "user1-11111111") // Different first 8 chars
-		req.RemoteAddr = "192.168.1.1:12345"            // Explicit IP for User 1
+		req.Header.Set("X-402-Nonce", "user1-11111111")
+		req.RemoteAddr = "192.168.1.1:12345" // Explicit IP for User 1
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		if w.Code != 200 {
@@ -201,8 +201,8 @@ func TestRateLimitMiddleware_DifferentKeys(t *testing.T) {
 	// User 2 should still be allowed (different bucket)
 	req2, _ := http.NewRequest("GET", "/test", nil)
 	req2.Header.Set("X-402-Signature", "sig2")
-	req2.Header.Set("X-402-Nonce", "user2-22222222") // Different first 8 chars
-	req2.RemoteAddr = "192.168.1.2:12345"            // Different IP for User 2
+	req2.Header.Set("X-402-Nonce", "user2-22222222")
+	req2.RemoteAddr = "192.168.1.2:12345" // Different IP for User 2
 	w2 := httptest.NewRecorder()
 	r.ServeHTTP(w2, req2)
 	if w2.Code != 200 {

--- a/gateway/ratelimit.go
+++ b/gateway/ratelimit.go
@@ -31,7 +31,8 @@ type TokenBucket struct {
 	burst      int           // Maximum tokens in bucket
 	buckets    sync.Map      // map[string]*bucket - thread-safe map of user buckets
 	cleanupTTL time.Duration // Time after which inactive buckets are cleaned up
-	stopCh     chan struct{} // Channel to stop cleanup goroutine
+	stopCh     chan struct{}  // Channel to stop cleanup goroutine
+	stopOnce   sync.Once     // Ensures Stop() is safe to call multiple times
 }
 
 // NewTokenBucket creates a new TokenBucket rate limiter
@@ -144,8 +145,9 @@ func (tb *TokenBucket) GetResetTime(key string) int64 {
 
 // Stop stops the background cleanup goroutine. Call this when the
 // TokenBucket is no longer needed to avoid goroutine leaks.
+// Safe to call multiple times.
 func (tb *TokenBucket) Stop() {
-	close(tb.stopCh)
+	tb.stopOnce.Do(func() { close(tb.stopCh) })
 }
 
 // cleanup runs in a background goroutine to remove stale buckets.

--- a/gateway/ratelimit.go
+++ b/gateway/ratelimit.go
@@ -142,12 +142,14 @@ func (tb *TokenBucket) GetResetTime(key string) int64 {
 	return resetTime.Unix()
 }
 
-// cleanup runs in a background goroutine to remove stale buckets
-// This prevents memory leaks from inactive users
+// Stop stops the background cleanup goroutine. Call this when the
+// TokenBucket is no longer needed to avoid goroutine leaks.
 func (tb *TokenBucket) Stop() {
 	close(tb.stopCh)
 }
 
+// cleanup runs in a background goroutine to remove stale buckets.
+// This prevents memory leaks from inactive users.
 func (tb *TokenBucket) cleanup() {
 	ticker := time.NewTicker(tb.cleanupTTL)
 	defer ticker.Stop()


### PR DESCRIPTION
Closes #100

## Problem
The current rate limiter used nonce-based keying for authenticated requests. Since nonces must be unique per request (to prevent replay attacks), every request created a new rate limit bucket, resulting in:
- Infinite rate limits for authenticated users
- Memory leaks from unbounded bucket creation

## Solution
Changed to IP-based rate limiting for all requests to prevent infinite-bucket attacks.

## Changes
- Modified `getRateLimitKey()` to always return IP-based keys
- Updated `TestGetRateLimitKey` to validate IP-based behavior
- Removed nonce-based keying logic

## Testing
- Updated unit tests to reflect new behavior
- Tests will run in CI pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional trusted-proxies configuration at startup to control how client IPs are derived.

* **Bug Fixes**
  * Rate limiting now keys strictly by client IP for consistent per-IP throttling.
  * Background rate-limit cleanup stops cleanly on shutdown to avoid lingering processes.

* **Tests**
  * Updated rate-limit tests to validate IP-based keying and per-IP behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces nonce-based rate limiting with IP-based rate limiting to fix the infinite bucket memory leak issue.

**Key Changes:**
- Removed nonce-based keying in `getRateLimitKey()` - now always returns IP-based keys
- Added `TRUSTED_PROXIES` configuration to prevent X-Forwarded-For spoofing 
- Fixed double-close panic in `TokenBucket.Stop()` using `sync.Once`
- Updated tests to validate IP-based rate limiting behavior

**Issues Found:**
- Test comment at line 158 is misleading - claims "different users have separate buckets" but with IP-based limiting, users sharing an IP share buckets
- Outdated comments referencing nonce characteristics (lines 181, 204) should be cleaned up
- The main architectural issue (already documented in previous threads): authenticated users behind corporate NAT/VPNs unfairly share rate limits

**Positive Changes:**
- Successfully prevents infinite bucket attacks from unique nonces
- Proper trusted proxy configuration prevents IP spoofing
- Good defensive programming with `sync.Once` to prevent goroutine panics

<h3>Confidence Score: 2/5</h3>

- This PR addresses the infinite bucket vulnerability but introduces a critical fairness issue for authenticated users behind shared IPs
- While the PR successfully fixes the memory leak from nonce-based keying and adds proper proxy configuration, the IP-based approach breaks the intended rate limiting model where authenticated users should have individual limits based on their wallet address, not shared limits based on IP
- Pay close attention to `gateway/main.go` (rate limiting logic) and `gateway/main_test.go` (misleading test assertions)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/main.go | Changed to IP-based rate limiting and added trusted proxy configuration, but creates critical issue where authenticated users sharing an IP share rate limits |
| gateway/main_test.go | Updated tests for IP-based rate limiting, but test comments are misleading and don't reflect actual behavior |
| gateway/ratelimit.go | Added sync.Once to prevent double-close panic in Stop() method - good defensive fix |

</details>



<sub>Last reviewed commit: e5d212a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->