### PR TITLE
feat: make request body size configurable via MAX_REQUEST_BODY_MB

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ VERIFIER_TIMEOUT_SECONDS=2
 # Health check timeout (seconds)
 HEALTH_CHECK_TIMEOUT_SECONDS=2
 
+# Request Body Size Configuration
+# Maximum request body size in megabytes (default: 10MB)
+MAX_REQUEST_BODY_MB=10
+
 
 
 # Redis Configuration (for Caching)

--- a/gateway/cache.go
+++ b/gateway/cache.go
@@ -47,11 +47,11 @@ func CacheMiddleware() gin.HandlerFunc {
 
 		// Read request body to generate cache key
 		// Check Content-Length first to reject oversized requests immediately
-		const maxBodySize = 10 * 1024 * 1024
+		maxBodySize := getMaxBodySize()
 		// ContentLength == -1 means unknown (chunked encoding or no header), proceed to MaxBytesReader
 		if c.Request.ContentLength > maxBodySize {
 			c.Header("Connection", "close")
-			c.JSON(413, gin.H{"error": "Payload too large", "max_size": "10MB"})
+			c.JSON(413, gin.H{"error": "Payload too large", "max_size_mb": maxBodySize / (1024 * 1024)})
 			c.Abort()
 			return
 		}
@@ -59,14 +59,14 @@ func CacheMiddleware() gin.HandlerFunc {
 		var requestBody []byte
 		var err error
 		if c.Request.Body != nil {
-			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, int64(maxBodySize))
+			c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBodySize)
 			requestBody, err = io.ReadAll(c.Request.Body)
 			if err != nil {
 				// If body too large, MaxBytesReader returns error
 				var maxBytesErr *http.MaxBytesError
 				if errors.As(err, &maxBytesErr) {
 					c.Header("Connection", "close")
-					c.JSON(413, gin.H{"error": "Payload too large", "max_size": "10MB"})
+					c.JSON(413, gin.H{"error": "Payload too large", "max_size_mb": maxBodySize / (1024 * 1024)})
 					c.Abort()
 					return
 				}

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -24,5 +24,8 @@ func getHealthCheckTimeout() time.Duration {
 // Configurable via MAX_REQUEST_BODY_MB environment variable (default: 10MB).
 func getMaxBodySize() int64 {
 	mb := getEnvAsInt("MAX_REQUEST_BODY_MB", 10)
+	if mb <= 0 {
+		mb = 10
+	}
 	return int64(mb) * 1024 * 1024
 }

--- a/gateway/config.go
+++ b/gateway/config.go
@@ -19,3 +19,10 @@ func getVerifierTimeout() time.Duration { return getPositiveTimeout("VERIFIER_TI
 func getHealthCheckTimeout() time.Duration {
 	return getPositiveTimeout("HEALTH_CHECK_TIMEOUT_SECONDS", 2)
 }
+
+// getMaxBodySize returns the maximum request body size in bytes.
+// Configurable via MAX_REQUEST_BODY_MB environment variable (default: 10MB).
+func getMaxBodySize() int64 {
+	mb := getEnvAsInt("MAX_REQUEST_BODY_MB", 10)
+	return int64(mb) * 1024 * 1024
+}

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -257,3 +257,44 @@ func TestTimeoutConfigHelpers(t *testing.T) {
 		t.Fatalf("expected request timeout to fall back to 60s on non-positive value, got %v", getRequestTimeout())
 	}
 }
+
+func TestGetMaxBodySize(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected int64
+	}{
+		{
+			name:     "default 10MB",
+			envValue: "",
+			expected: 10 * 1024 * 1024,
+		},
+		{
+			name:     "custom 1MB",
+			envValue: "1",
+			expected: 1 * 1024 * 1024,
+		},
+		{
+			name:     "custom 50MB",
+			envValue: "50",
+			expected: 50 * 1024 * 1024,
+		},
+		{
+			name:     "custom 100MB",
+			envValue: "100",
+			expected: 100 * 1024 * 1024,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("MAX_REQUEST_BODY_MB", tt.envValue)
+			}
+			result := getMaxBodySize()
+			if result != tt.expected {
+				t.Errorf("expected %d bytes, got %d bytes", tt.expected, result)
+			}
+		})
+	}
+}

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -298,9 +298,8 @@ func TestGetMaxBodySize(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.envValue != "" {
-				t.Setenv("MAX_REQUEST_BODY_MB", tt.envValue)
-			}
+			// Always set env to prevent leakage between tests
+			t.Setenv("MAX_REQUEST_BODY_MB", tt.envValue)
 			result := getMaxBodySize()
 			if result != tt.expected {
 				t.Errorf("expected %d bytes, got %d bytes", tt.expected, result)

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -284,6 +284,16 @@ func TestGetMaxBodySize(t *testing.T) {
 			envValue: "100",
 			expected: 100 * 1024 * 1024,
 		},
+		{
+			name:     "zero falls back to default",
+			envValue: "0",
+			expected: 10 * 1024 * 1024,
+		},
+		{
+			name:     "negative falls back to default",
+			envValue: "-5",
+			expected: 10 * 1024 * 1024,
+		},
 	}
 
 	for _, tt := range tests {

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -368,13 +368,13 @@ func handleSummarize(c *gin.Context) {
 	// Read body if not already available
 	if requestBody == nil {
 		// Read body with limit (only if middleware didn't process it)
-		const maxBodySize = 10 * 1024 * 1024
-		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, int64(maxBodySize))
+		maxBodySize := getMaxBodySize()
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBodySize)
 		requestBody, err = io.ReadAll(c.Request.Body)
 		if err != nil {
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(err, &maxBytesErr) {
-				c.JSON(413, gin.H{"error": "Payload too large", "max_size": "10MB"})
+				c.JSON(413, gin.H{"error": "Payload too large", "max_size_mb": getEnvAsInt("MAX_REQUEST_BODY_MB", 10)})
 			} else {
 				c.JSON(500, gin.H{"error": "Failed to read request body"})
 			}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -374,7 +374,7 @@ func handleSummarize(c *gin.Context) {
 		if err != nil {
 			var maxBytesErr *http.MaxBytesError
 			if errors.As(err, &maxBytesErr) {
-				c.JSON(413, gin.H{"error": "Payload too large", "max_size_mb": getEnvAsInt("MAX_REQUEST_BODY_MB", 10)})
+				c.JSON(413, gin.H{"error": "Payload too large", "max_size_mb": maxBodySize / (1024 * 1024)})
 			} else {
 				c.JSON(500, gin.H{"error": "Failed to read request body"})
 			}


### PR DESCRIPTION
## 🎯 Description

This PR makes the request body size limit configurable via the `MAX_REQUEST_BODY_MB` environment variable, replacing the hardcoded 10MB limit in the Gateway service.

Fixes #116

## 🔧 Changes Made

### 1. Added Configuration Helper (`gateway/config.go`)
- Implemented `getMaxBodySize()` function that reads `MAX_REQUEST_BODY_MB` from environment
- Returns size in bytes (MB × 1024 × 1024)
- Defaults to 10MB if not set

### 2. Updated Request Handler (`gateway/main.go`)
- Removed hardcoded `const maxBodySize = 10 * 1024 * 1024`
- Replaced with dynamic call to `getMaxBodySize()`
- Updated error response to show actual configured limit in `max_size_mb` field

### 3. Added Documentation (`.env.example`)
- Added `MAX_REQUEST_BODY_MB=10` with clear comments
- Placed in Request Configuration section for easy discovery

### 4. Added Tests (`gateway/config_test.go`)
- Comprehensive unit tests for `getMaxBodySize()`
- Tests default value (10MB)
- Tests custom values (1MB, 50MB, 100MB)
- Follows existing test patterns

## 📊 Impact

- **Backward Compatible**: Default remains 10MB
- **Production Ready**: Allows different deployments to configure limits based on needs
- **DoS Protection**: Enables restricting payload sizes to prevent memory attacks
- **Large Documents**: Supports increasing limits for summarization of larger texts

## ✅ Testing

- [x] Added unit tests for `getMaxBodySize()`
- [x] All tests follow existing patterns
- [x] Default behavior unchanged (10MB)
- [x] Configuration properly documented

## 📝 Usage Example

```bash
# Set 1MB limit for testing
MAX_REQUEST_BODY_MB=1

# Set 50MB limit for large documents
MAX_REQUEST_BODY_MB=50

🔍 Code Quality
Follows Go idioms and project conventions
Consistent with existing timeout configuration helpers
Clear comments and documentation
Minimal, focused changes
📦 Files Changed
.env.example - Added configuration variable
config.go
 - Added helper function
config_test.go
 - Added unit tests
main.go
 - Updated handler to use dynamic configuration
```
 Ready for review! 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request body size limit is now configurable via an environment variable (default: 10 MB).

* **Chores**
  * Error responses for oversized payloads use a clearer field name indicating the limit in MB.

* **Tests**
  * Added unit tests covering default, custom, zero and negative configuration scenarios.

* **Documentation**
  * Example environment file updated with the new configuration option and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes request body size configurable via `MAX_REQUEST_BODY_MB`, but **critically**, it only updates `main.go` and misses `cache.go`, which still has a hardcoded 10MB limit. This creates inconsistent behavior where cached requests ignore the configuration.

**Critical Issues:**
- `gateway/cache.go` lines 50, 52, 62, 54, 69 still use hardcoded `10 * 1024 * 1024` and `"10MB"` strings
- When caching is enabled, the configurable limit is completely bypassed
- `getMaxBodySize()` lacks validation for non-positive values (unlike other timeout helpers)

**Minor Issues:**
- Error response on line 377 duplicates logic by calling `getEnvAsInt()` again instead of reusing `maxBodySize`
- Tests missing edge cases for zero/negative values

<h3>Confidence Score: 1/5</h3>

- This PR has a critical bug that breaks the feature when caching is enabled
- The implementation is incomplete - `cache.go` still has hardcoded 10MB limits in multiple places (lines 50, 52, 62, 54, 69), which means the configurable body size only works when caching is disabled. Additionally, missing validation allows invalid values like 0 or negative numbers.
- `gateway/cache.go` must be updated to use `getMaxBodySize()` instead of hardcoded limits, and `gateway/config.go` needs validation for non-positive values

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| gateway/config.go | Added `getMaxBodySize()` helper but missing validation for non-positive values |
| gateway/config_test.go | Added tests for `getMaxBodySize()` but missing edge cases for zero/negative values |
| gateway/main.go | Updated to use `getMaxBodySize()` but incomplete - `cache.go` still has hardcoded 10MB limit causing inconsistent behavior, and error response duplicates logic |
| .env.example | Added `MAX_REQUEST_BODY_MB` configuration with clear documentation |

</details>



<sub>Last reviewed commit: 4e494c3</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->