### PR TITLE
ci: enable @claude mentions via Claude Code GitHub App

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Optional: pin a model. Default is Sonnet. Uncomment to force Opus 4.7.
+          # claude_args: |
+          #   --model claude-opus-4-7
+          #   --max-turns 15


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude.yml` so tagging `@claude` in any issue, PR comment, or PR review triggers the [`anthropics/claude-code-action@v1`](https://github.com/anthropics/claude-code-action) bot.
- Authenticates via `CLAUDE_CODE_OAUTH_TOKEN` (Max 5x OAuth) rather than a metered `ANTHROPIC_API_KEY` — usage counts against the Max subscription quota.
- Job-level `if:` gates the run on the `@claude` substring so unrelated comments don't burn Actions minutes (the action otherwise spins up a runner on every comment just to no-op).

## Post-merge setup (one-time, done manually)
1. Install the official Claude GitHub App on this repo: https://github.com/apps/claude
2. Mint an OAuth token tied to the Max plan: `claude setup-token`
3. Store it as a repo secret: `gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo AnkanMisra/MicroAI-Paygate`

## Test plan
- [ ] Merge this PR.
- [ ] After installing the GitHub App and setting `CLAUDE_CODE_OAUTH_TOKEN`, comment `@claude hello` on any open PR or test issue.
- [ ] Verify the `Claude Code` workflow run starts within ~30s and `claude[bot]` replies.
- [ ] Comment without `@claude` on another PR — confirm no workflow run starts (proves the `if:` gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Claude Code GitHub Actions workflow enabling automated code assistance. The workflow activates on @claude mentions in issue comments, pull request reviews, and issue assignments, providing intelligent code analysis and recommendations within your development workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/150)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->