### PR TITLE
docs(gateway): add missing error codes to README

### DIFF
--- a/gateway/README.md
+++ b/gateway/README.md
@@ -143,7 +143,10 @@ The gateway exposes sanitized public errors and logs internal details with a `co
 - `verifier_timeout`
 - `upstream_unavailable`
 - `upstream_timeout`
+- `request_body_read_failed`
+- `response_encoding_failed`
 - `receipt_generation_failed`
 - `receipt_store_failed`
+- `receipt_encoding_failed`
 
 Do not expose verifier internals, provider response bodies, private keys, Redis URLs, or raw secrets in public responses.


### PR DESCRIPTION
## Summary
- Sync the API Errors list in `gateway/README.md` with the enum in `gateway/openapi.yaml`
- Adds `request_body_read_failed`, `response_encoding_failed`, and `receipt_encoding_failed`

## Test plan
- [x] Verified the new codes match the enum in `gateway/openapi.yaml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01XNJeLJCTdJ4967bVvm6NCB)_