### PR TITLE
test(gateway): expand OpenAPI route coverage test

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/redis/go-redis/v9 v9.17.2
 	github.com/stretchr/testify v1.11.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -53,5 +54,4 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -268,30 +268,10 @@ func main() {
 		log.Fatalf("Receipt store initialization failed: %v", err)
 	}
 
-	r.StaticFile("/openapi.yaml", "openapi.yaml")
-
-	r.GET("/docs", func(c *gin.Context) {
-		c.Header("Content-Type", "text/html")
-		c.String(200, `
-<!DOCTYPE html>
-<html>
-<head>
-  <title>MicroAI Paygate Docs</title>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
-</head>
-<body>
-  <div id="swagger-ui"></div>
-  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
-  <script>
-    SwaggerUIBundle({
-      url: '/openapi.yaml',
-      dom_id: '#swagger-ui'
-    });
-  </script>
-</body>
-</html>
-`)
-	})
+	// Documentation routes are registered before CORS / rate-limit / timeout
+	// middleware so the Swagger UI and raw spec are served without those
+	// constraints.
+	registerDocRoutes(r)
 
 	r.Use(cors.New(cors.Config{
 		AllowOrigins: getAllowedOrigins(),
@@ -329,25 +309,12 @@ func main() {
 	// deadline when nested timeouts are present to avoid surprising behavior.
 	r.Use(RequestTimeoutMiddleware(getRequestTimeout()))
 
-	//health check if server is up
-	r.GET("/healthz", handleHealthz)
-
-	//readiness check
-	r.GET("/readyz", handleReadyz)
-
-	// AI endpoints with AI-specific timeout (30s)
-	aiGroup := r.Group("/api/ai")
-	aiGroup.Use(RequestTimeoutMiddleware(getAITimeout()))
-	if getCacheEnabled() {
-		aiGroup.POST("/summarize", CacheMiddleware(), handleSummarize)
-	} else {
-		aiGroup.POST("/summarize", handleSummarize)
-	}
-
-	// Receipt lookup endpoint
-	// Note: Rate limiting applies only if enabled globally via RATE_LIMIT_ENABLED=true
-	// Random 12-char receipt IDs (2^48 space) make brute-force enumeration impractical
-	r.GET("/api/receipts/:id", handleGetReceipt)
+	// Public API routes. Kept in registerAPIRoutes so the OpenAPI coverage
+	// test in openapi_test.go can introspect them without booting middleware.
+	// Rate limiting (if enabled) applies via the global r.Use above; random
+	// 12-char receipt IDs (2^48 space) make /api/receipts/:id brute-force
+	// enumeration impractical.
+	registerAPIRoutes(r)
 
 	// Initialize receipt cleanup goroutine
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())

--- a/gateway/openapi_test.go
+++ b/gateway/openapi_test.go
@@ -18,7 +18,9 @@ func TestOpenAPISpecMatchesRoutes(t *testing.T) {
 
 	expectedPaths := []string{
 		"/healthz",
+		"/readyz",
 		"/api/ai/summarize",
+		"/api/receipts/{id}",
 	}
 
 	for _, path := range expectedPaths {

--- a/gateway/openapi_test.go
+++ b/gateway/openapi_test.go
@@ -5,27 +5,66 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gopkg.in/yaml.v3"
 )
 
+// ginPathToOpenAPI converts a gin route pattern to its OpenAPI path equivalent.
+// gin uses :name and *name for params; OpenAPI uses {name}.
+func ginPathToOpenAPI(p string) string {
+	parts := strings.Split(p, "/")
+	for i, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+		if part[0] == ':' || part[0] == '*' {
+			parts[i] = "{" + part[1:] + "}"
+		}
+	}
+	return strings.Join(parts, "/")
+}
+
+// TestOpenAPISpecMatchesRoutes enforces bidirectional alignment between the
+// API surface registered by registerAPIRoutes and the paths documented in
+// openapi.yaml. Documentation-meta routes (/docs, /openapi.yaml) live in
+// registerDocRoutes and are intentionally excluded from the API contract.
 func TestOpenAPISpecMatchesRoutes(t *testing.T) {
-	specPath := filepath.Join(".", "openapi.yaml")
-	data, err := os.ReadFile(specPath)
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerAPIRoutes(r)
+
+	data, err := os.ReadFile(filepath.Join(".", "openapi.yaml"))
 	if err != nil {
-		t.Fatalf("failed to read openapi.yaml: %v", err)
+		t.Fatalf("read openapi.yaml: %v", err)
+	}
+	var spec struct {
+		Paths map[string]map[string]any `yaml:"paths"`
+	}
+	if err := yaml.Unmarshal(data, &spec); err != nil {
+		t.Fatalf("parse openapi.yaml: %v", err)
 	}
 
-	spec := string(data)
-
-	expectedPaths := []string{
-		"/healthz",
-		"/readyz",
-		"/api/ai/summarize",
-		"/api/receipts/{id}",
+	registered := make(map[string]bool, len(r.Routes()))
+	for _, route := range r.Routes() {
+		path := ginPathToOpenAPI(route.Path)
+		registered[path] = true
+		if _, ok := spec.Paths[path]; !ok {
+			t.Errorf("route %s %s is registered but missing from openapi.yaml paths", route.Method, path)
+		}
 	}
 
-	for _, path := range expectedPaths {
-		if !strings.Contains(spec, path) {
-			t.Errorf("OpenAPI spec missing path: %s", path)
+	for path := range spec.Paths {
+		if !registered[path] {
+			t.Errorf("openapi.yaml documents path %s but no API route is registered for it", path)
+		}
+	}
+
+	// Defense-in-depth: hard-require the four paths called out in issue #164.
+	required := []string{"/healthz", "/readyz", "/api/ai/summarize", "/api/receipts/{id}"}
+	for _, p := range required {
+		if _, ok := spec.Paths[p]; !ok {
+			t.Errorf("openapi.yaml is missing required path: %s", p)
 		}
 	}
 }

--- a/gateway/routes.go
+++ b/gateway/routes.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// swaggerUIPage is the HTML served at GET /docs.
+const swaggerUIPage = `
+<!DOCTYPE html>
+<html>
+<head>
+  <title>MicroAI Paygate Docs</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui.css" />
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5.11.0/swagger-ui-bundle.js"></script>
+  <script>
+    SwaggerUIBundle({
+      url: '/openapi.yaml',
+      dom_id: '#swagger-ui'
+    });
+  </script>
+</body>
+</html>
+`
+
+// registerDocRoutes wires the documentation-meta routes. These serve the raw
+// OpenAPI spec and the Swagger UI; they are deliberately NOT part of the
+// public API contract documented in openapi.yaml, which is why the OpenAPI
+// coverage test only inspects registerAPIRoutes.
+func registerDocRoutes(r *gin.Engine) {
+	r.StaticFile("/openapi.yaml", "openapi.yaml")
+	r.GET("/docs", func(c *gin.Context) {
+		c.Header("Content-Type", "text/html")
+		c.String(200, swaggerUIPage)
+	})
+}
+
+// registerAPIRoutes wires every public API route that must be documented in
+// gateway/openapi.yaml. openapi_test.go iterates this surface and fails if
+// any registered route is missing from the spec, or vice versa.
+func registerAPIRoutes(r *gin.Engine) {
+	r.GET("/healthz", handleHealthz)
+	r.GET("/readyz", handleReadyz)
+
+	aiGroup := r.Group("/api/ai")
+	aiGroup.Use(RequestTimeoutMiddleware(getAITimeout()))
+	if getCacheEnabled() {
+		aiGroup.POST("/summarize", CacheMiddleware(), handleSummarize)
+	} else {
+		aiGroup.POST("/summarize", handleSummarize)
+	}
+
+	r.GET("/api/receipts/:id", handleGetReceipt)
+}


### PR DESCRIPTION
## Summary
- Extend `gateway/openapi_test.go` to require `/readyz` and `/api/receipts/{id}` in `openapi.yaml`

Fixes #164

## Test plan
- [x] `cd gateway && go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OpenAPI specification test to validate two additional API route patterns: `/readyz` and `/api/receipts/{id}`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->