### PR TITLE
Show verified x402 receipt status

### DIFF
--- a/web/src/components/output-card.tsx
+++ b/web/src/components/output-card.tsx
@@ -1,4 +1,8 @@
-import type { SignedReceipt } from "@/lib/verify-receipt";
+"use client";
+
+import { useEffect, useState } from "react";
+import { verifyReceipt, type SignedReceipt } from "@/lib/verify-receipt";
+import { Badge } from "./ui/badge";
 import { CopyButton } from "./copy-button";
 
 type Props = {
@@ -6,7 +10,11 @@ type Props = {
   receipt: SignedReceipt | null;
 };
 
+type ReceiptVerifyState = "missing" | "verifying" | "valid" | "invalid";
+
 export function OutputCard({ summary, receipt }: Props) {
+  const verifyState = useReceiptVerification(receipt);
+
   if (!summary) return null;
 
   return (
@@ -16,13 +24,7 @@ export function OutputCard({ summary, receipt }: Props) {
           <span className="font-mono text-[10px] uppercase tracking-[0.16em] tnum text-ink-soft">
             Output
           </span>
-          {receipt && (
-            // Neutral copy — receipt presence proves the gateway sent one, not
-            // that it has been cryptographically verified. Green "✓ Valid"
-            // lives on the receipt-card after the user clicks Verify signature
-            // and the keccak/ECDSA recovery actually runs.
-            <span className="font-display text-sm italic text-ink-soft">receipt returned</span>
-          )}
+          <ReceiptStatusBadge state={verifyState} />
         </div>
         <CopyButton value={summary} label="Copy summary" />
       </header>
@@ -31,19 +33,72 @@ export function OutputCard({ summary, receipt }: Props) {
           {summary}
         </p>
       </div>
-      {receipt && (
-        <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-ink bg-paper-deep px-5 py-3">
-          <div className="min-w-0 flex items-center gap-2">
+      <footer className="flex flex-wrap items-center justify-between gap-3 border-t border-ink bg-paper-deep px-5 py-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-ink-soft">
               Receipt
             </span>
-            <code className="truncate font-mono text-xs tnum text-ink">
-              {receipt.receipt.id}
-            </code>
+            {receipt ? (
+              <code className="truncate font-mono text-xs tnum text-ink">
+                {receipt.receipt.id}
+              </code>
+            ) : (
+              <span className="font-mono text-xs text-ink-soft">not returned</span>
+            )}
           </div>
-          <CopyButton value={receipt.receipt.id} label="Copy receipt ID" />
-        </footer>
-      )}
+          <p className="font-sans text-xs text-ink-soft">
+            {describeReceiptState(verifyState)}
+          </p>
+        </div>
+        {receipt && <CopyButton value={receipt.receipt.id} label="Copy receipt ID" />}
+      </footer>
     </article>
   );
+}
+
+function useReceiptVerification(receipt: SignedReceipt | null): ReceiptVerifyState {
+  const [result, setResult] = useState<{
+    id: string | null;
+    state: Exclude<ReceiptVerifyState, "missing" | "verifying">;
+  }>({ id: null, state: "invalid" });
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!receipt) return undefined;
+
+    void verifyReceipt(receipt).then((ok) => {
+      if (!cancelled) {
+        setResult({ id: receipt.receipt.id, state: ok ? "valid" : "invalid" });
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [receipt]);
+
+  if (!receipt) return "missing";
+  if (result.id !== receipt.receipt.id) return "verifying";
+  return result.state;
+}
+
+function ReceiptStatusBadge({ state }: { state: ReceiptVerifyState }) {
+  if (state === "valid") return <Badge tone="ok">✓ Receipt verified</Badge>;
+  if (state === "invalid") return <Badge tone="alert">✗ Receipt not verified</Badge>;
+  if (state === "verifying") return <Badge tone="muted">Verifying receipt…</Badge>;
+  return <Badge tone="muted">Receipt not returned</Badge>;
+}
+
+function describeReceiptState(state: ReceiptVerifyState): string {
+  if (state === "valid") {
+    return "The signed X-402 receipt was decoded and its gateway signature verified in this browser.";
+  }
+  if (state === "invalid") {
+    return "The X-402 receipt was decoded, but the gateway signature did not verify.";
+  }
+  if (state === "verifying") {
+    return "The X-402 receipt was decoded and signature verification is running locally.";
+  }
+  return "The summary succeeded without an X-402-Receipt header, so there is no receipt ID to verify.";
 }

--- a/web/src/components/output-card.tsx
+++ b/web/src/components/output-card.tsx
@@ -67,11 +67,17 @@ function useReceiptVerification(receipt: SignedReceipt | null): ReceiptVerifySta
     let cancelled = false;
     if (!receipt) return undefined;
 
-    void verifyReceipt(receipt).then((ok) => {
-      if (!cancelled) {
-        setResult({ id: receipt.receipt.id, state: ok ? "valid" : "invalid" });
-      }
-    });
+    void verifyReceipt(receipt)
+      .then((ok) => {
+        if (!cancelled) {
+          setResult({ id: receipt.receipt.id, state: ok ? "valid" : "invalid" });
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResult({ id: receipt.receipt.id, state: "invalid" });
+        }
+      });
 
     return () => {
       cancelled = true;

--- a/web/src/components/wallet-widget.tsx
+++ b/web/src/components/wallet-widget.tsx
@@ -46,13 +46,16 @@ export function WalletWidget() {
   useEffect(() => {
     let mounted = true;
 
-    if (!hasWallet()) {
-      setState({ kind: "missing" });
-      return;
-    }
-
     async function load() {
       try {
+        await Promise.resolve();
+        if (!mounted) return;
+
+        if (!hasWallet()) {
+          setState({ kind: "missing" });
+          return;
+        }
+
         const [addr, chain] = await Promise.all([getCurrentAccount(), getCurrentChainId()]);
         if (!mounted) return;
         if (addr && chain != null) {
@@ -69,6 +72,12 @@ export function WalletWidget() {
       }
     }
     void load();
+
+    if (!hasWallet()) {
+      return () => {
+        mounted = false;
+      };
+    }
 
     const unsubAcc = subscribeAccountsChanged(async (accounts) => {
       if (!accounts[0]) {

--- a/web/src/components/wallet-widget.tsx
+++ b/web/src/components/wallet-widget.tsx
@@ -45,6 +45,8 @@ export function WalletWidget() {
 
   useEffect(() => {
     let mounted = true;
+    let unsubAcc: (() => void) | undefined;
+    let unsubChain: (() => void) | undefined;
 
     async function load() {
       try {
@@ -55,6 +57,29 @@ export function WalletWidget() {
           setState({ kind: "missing" });
           return;
         }
+
+        unsubAcc = subscribeAccountsChanged(async (accounts) => {
+          if (!accounts[0]) {
+            setState({ kind: "disconnected" });
+            return;
+          }
+          // Read the live chainId — otherwise an external connect lands us in
+          // `chainId: 0`, which is never a real EVM chain and triggers the
+          // wrong-chain CTA even when the wallet is already correct.
+          const chain = await getCurrentChainId();
+          setState((prev) =>
+            prev.kind === "connected"
+              ? { ...prev, address: accounts[0] }
+              : { kind: "connected", address: accounts[0], chainId: chain ?? 0 },
+          );
+        });
+
+        unsubChain = subscribeChainChanged((hex) => {
+          const chainId = parseInt(hex, 16);
+          setState((prev) =>
+            prev.kind === "connected" ? { ...prev, chainId } : prev,
+          );
+        });
 
         const [addr, chain] = await Promise.all([getCurrentAccount(), getCurrentChainId()]);
         if (!mounted) return;
@@ -73,39 +98,10 @@ export function WalletWidget() {
     }
     void load();
 
-    if (!hasWallet()) {
-      return () => {
-        mounted = false;
-      };
-    }
-
-    const unsubAcc = subscribeAccountsChanged(async (accounts) => {
-      if (!accounts[0]) {
-        setState({ kind: "disconnected" });
-        return;
-      }
-      // Read the live chainId — otherwise an external connect lands us in
-      // `chainId: 0`, which is never a real EVM chain and triggers the
-      // wrong-chain CTA even when the wallet is already correct.
-      const chain = await getCurrentChainId();
-      setState((prev) =>
-        prev.kind === "connected"
-          ? { ...prev, address: accounts[0] }
-          : { kind: "connected", address: accounts[0], chainId: chain ?? 0 },
-      );
-    });
-
-    const unsubChain = subscribeChainChanged((hex) => {
-      const chainId = parseInt(hex, 16);
-      setState((prev) =>
-        prev.kind === "connected" ? { ...prev, chainId } : prev,
-      );
-    });
-
     return () => {
       mounted = false;
-      unsubAcc();
-      unsubChain();
+      unsubAcc?.();
+      unsubChain?.();
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Fixes #163 by surfacing the signed x402 receipt status directly in the successful summarize result.

Changes:
- decode/use the returned `X-402-Receipt` via the existing receipt flow;
- verify the receipt signature in-browser with the existing `verifyReceipt()` helper;
- show a compact result badge for `verified`, `not verified`, `verifying`, or `receipt not returned`;
- display the receipt ID when present and keep a clear non-crashing status when the header is missing;
- avoid exposing raw receipt headers or sensitive signature material in the result UI.

I also fixed the current React lint rule violation in `wallet-widget.tsx` by deferring the initial missing-wallet state update out of the synchronous effect body, so the requested web gates can pass cleanly.

## Verification

From `web/`:

- `npm run lint` ✅
- `npm run test` (`tsc --noEmit`) ✅
- `npm run build` ✅
- `git diff --check` ✅

Note: `bun` is not installed in this Windows runner, so I used the equivalent package scripts through npm after `npm install --ignore-scripts`. No package-lock changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Receipt verification status now displays in the output card with a visual badge indicating whether receipts are valid, invalid, verifying, missing, or not returned. Added descriptive messages for each verification state.

* **Bug Fixes**
  * Enhanced wallet loading flow and wallet change subscription handling for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->