### PR TITLE
[codex] add deterministic mock E2E flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ PORT=3000
 NODE_ENV=development
 
 # AI Service Configuration
-# AI provider selection: "openrouter" (default) or "ollama"
-AI_PROVIDER=openrouter
+# AI provider selection: "mock" for local demos/CI, "openrouter" for live hosted AI, or "ollama" for local Ollama.
+AI_PROVIDER=mock
 
 # OpenRouter Configuration (when AI_PROVIDER=openrouter)
 OPENROUTER_API_KEY=your_openrouter_key_here
@@ -17,6 +17,10 @@ OPENROUTER_MODEL=z-ai/glm-4.5-air:free
 # Ollama Configuration (when AI_PROVIDER=ollama)
 # OLLAMA_URL=http://localhost:11434
 # OLLAMA_MODEL=llama2
+
+# Mock Configuration (when AI_PROVIDER=mock)
+# No model provider or API key is required. Use this for deterministic local
+# demos and CI payment-flow tests.
 
 # Payment Configuration
 # Private key for the server wallet (recipient of payments) - REQUIRED

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,49 +39,35 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     env:
-      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'z-ai/glm-4.5-air:free' }}
+      AI_PROVIDER: mock
       RECEIPT_STORE: memory
       CACHE_ENABLED: "false"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Check OpenRouter key
-        run: |
-          if [ -z "$OPENROUTER_API_KEY" ]; then
-            echo "OPENROUTER_API_KEY not set; skipping E2E."
-            exit 0
-          fi
-
       - name: Set up Go
-        if: env.OPENROUTER_API_KEY != ''
         uses: actions/setup-go@v6
         with:
           go-version: '1.24.x'
 
       - name: Set up Rust
-        if: env.OPENROUTER_API_KEY != ''
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Bun
-        if: env.OPENROUTER_API_KEY != ''
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: '1.3.13'
 
       - name: Install JS deps
-        if: env.OPENROUTER_API_KEY != ''
         run: bun install
 
       - name: Prep Go/Rust deps
-        if: env.OPENROUTER_API_KEY != ''
         run: |
-          go mod download
-          cargo fetch
+          (cd gateway && go mod download)
+          (cd verifier && cargo fetch)
 
-      - name: Run E2E (requires API key)
-        if: env.OPENROUTER_API_KEY != ''
+      - name: Run E2E
         run: |
           chmod +x ./run_e2e.sh
           timeout 150 ./run_e2e.sh

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,7 +9,7 @@ Free-tier deployment of MicroAI Paygate across three platforms. Total recurring 
 | `verifier/` (Rust) | Render Web Service | Free | Public over HTTPS; stateless EIP-712 recovery |
 | `gateway/` (Go) | Render Web Service | Free | Public; calls verifier and OpenRouter, talks to Redis |
 | `web/` (Next.js) | Vercel | Hobby | Built from `web/` subdirectory |
-| Redis | Upstash | Free | Receipt store + nonce replay protection |
+| Redis | Upstash | Free | Gateway receipt store and optional response cache |
 
 Both Render services share a region for low inter-service latency. Both **sleep after 15 minutes of inactivity** — the first request after sleep takes 30–50 seconds while the containers wake. The web app shows a warm-up banner during this window. See [Cold-start behavior](#cold-start-behavior) for details.
 
@@ -41,7 +41,7 @@ render workspace set
 ## 1. Provision Upstash Redis
 
 1. Sign up at https://upstash.com using GitHub OAuth.
-2. Console → **Create Database** → choose **Regional**, pick the region nearest your eventual Render region (e.g. Mumbai/`bom` or Singapore/`sin`), keep TLS enabled, leave eviction **off** for nonce-replay correctness.
+2. Console → **Create Database** → choose **Regional**, pick the region nearest your eventual Render region (e.g. Mumbai/`bom` or Singapore/`sin`), keep TLS enabled, leave eviction **off** so signed receipts are retained until their configured TTL.
 3. Open the database → **Connect to your database** → copy the `rediss://` URL (TLS). Save it — this is `REDIS_URL`.
 
 Quick sanity check:
@@ -52,7 +52,7 @@ redis-cli -u 'rediss://default:...@...upstash.io:6379' PING   # should print PON
 
 ## 2. Deploy the Verifier on Render
 
-The verifier is stateless EIP-712 signature recovery. Public on Render's free tier — acceptable because it exposes no secrets and only does cryptographic recovery on caller-supplied inputs.
+The verifier performs EIP-712 signature recovery and keeps nonce replay protection in single-process memory. Public on Render's free tier is acceptable for the demo because it exposes no secrets and only does cryptographic recovery on caller-supplied inputs. Run one verifier replica until Redis-backed verifier nonce storage exists.
 
 1. Render dashboard → **New +** → **Web Service** → connect `AnkanMisra/MicroAI-Paygate`.
 2. Configure:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 The backend services (gateway + verifier) are hosted on Render's free tier and **sleep after 15 minutes of inactivity**. The first request after a quiet period takes 30–50 seconds while both services wake. The web UI shows a brief warm-up banner during this window. Subsequent requests are normal speed.
 
-The deployed stack is **Render** (Rust verifier + Go gateway) + **Vercel** (Next.js web) + **Upstash** (Redis for nonces and signed receipts). All on free tiers — total recurring cost is $0. See [DEPLOY.md](DEPLOY.md) for the step-by-step deployment guide.
+The deployed stack is **Render** (Rust verifier + Go gateway) + **Vercel** (Next.js web) + **Upstash** (Redis-backed signed receipts and optional response cache). All on free tiers — total recurring cost is $0. See [DEPLOY.md](DEPLOY.md) for the step-by-step deployment guide.
 
 The demo runs on **Base Sepolia testnet**. A valid EIP-712 signature proves wallet authorization for the payment context; it does not move USDC on-chain. Bring a wallet on Base Sepolia to try the full sign-and-summarize flow.
 
@@ -66,7 +66,7 @@ flowchart TB
     Gateway["gateway/ Go Gin API :3000"]
     Verifier["verifier/ Rust Axum :3002"]
     Redis["Redis 7 receipt store by default\noptional response cache"]
-    AI["AI provider: OpenRouter or Ollama"]
+    AI["AI provider: mock, OpenRouter, or Ollama"]
     Wallet["EVM wallet on configured chain\nBase Sepolia default"]
 
     Client --> Web
@@ -107,7 +107,7 @@ flowchart TB
       Summarize["POST /api/ai/summarize"]
       PaymentContext["Create PaymentContext\nrecipient, token, amount, chainId, nonce, timestamp"]
       VerifyClient["Verifier HTTP client\nVERIFIER_URL"]
-      AIClient["AI provider client\nOpenRouter or Ollama"]
+      AIClient["AI provider client\nmock, OpenRouter, or Ollama"]
       ReceiptSigner["Receipt signer\nserver wallet key"]
       ReceiptLookup["GET /api/receipts/{id}"]
       Health["/healthz and /readyz"]
@@ -130,6 +130,7 @@ flowchart TB
     MemoryStore["In-memory receipt store\nquick start and tests when RECEIPT_STORE=memory"]
 
     subgraph Providers["AI providers"]
+      Mock["Deterministic mock summaries"]
       OpenRouter["OpenRouter chat completions"]
       Ollama["Local Ollama generate API"]
     end
@@ -146,6 +147,7 @@ flowchart TB
     VerifyRoute --> BodyLimit --> Domain --> Timestamp --> Nonce --> Recovery
     Recovery -->|valid or structured error_code| VerifyClient
     Summarize -->|verified cache miss| AIClient
+    AIClient --> Mock
     AIClient --> OpenRouter
     AIClient --> Ollama
     Summarize --> ReceiptSigner --> Receipts
@@ -238,12 +240,13 @@ cp .env.example .env
 
 Edit `.env` before starting the gateway. At minimum:
 
-- `OPENROUTER_API_KEY`: required when `AI_PROVIDER=openrouter`.
+- `AI_PROVIDER`: use `mock` for deterministic local demos, `openrouter` for live hosted AI, or `ollama` for local Ollama.
+- `OPENROUTER_API_KEY`: required only when `AI_PROVIDER=openrouter`.
 - `SERVER_WALLET_PRIVATE_KEY`: required for signing receipts. Use an unfunded development key locally.
 - `RECIPIENT_ADDRESS`: recipient address embedded in payment contexts.
 - `CHAIN_ID` and `EXPECTED_CHAIN_ID`: must match. The default is `84532` for Base Sepolia.
 
-The root `bun run stack` command starts the gateway with `RECEIPT_STORE=memory` and `CACHE_ENABLED=false` unless you exported different values in the shell. That means the normal quick start does not require Redis even though production-style receipt storage defaults to Redis.
+The root `bun run stack` command starts the gateway with `AI_PROVIDER=mock`, `RECEIPT_STORE=memory`, and `CACHE_ENABLED=false` unless you exported different values in the shell. That means the normal quick start does not require OpenRouter, Ollama, or Redis.
 
 ### Run The Stack
 
@@ -301,6 +304,9 @@ PAYGATE_SERVER_PUBLIC_KEY=0x...
 
 Use only unfunded local or test wallets. The SDK signs the same EIP-712 payment context as the web app and E2E tests, retries with the gateway's `X-402-*` headers, decodes `X-402-Receipt`, and verifies the receipt signature locally against the configured gateway receipt signing public key. If no trusted server public key is configured, receipt payload hashes are still checked but `receiptVerified` is `false`. It does not perform official x402 facilitator settlement.
 
+The SDK also includes `examples/verify-receipt.ts` for verifying a receipt ID or
+raw `X-402-Receipt` header against a trusted gateway receipt signing key.
+
 ### Docker Compose
 
 Docker Compose starts gateway, verifier, web, and Redis. It uses service names inside the Docker network, so the gateway reaches the verifier at `http://verifier:3002` and Redis at `redis:6379`.
@@ -316,8 +322,8 @@ Core local variables live in [.env.example](.env.example). Production placeholde
 
 | Variable | Service | Notes |
 | --- | --- | --- |
-| `AI_PROVIDER` | Gateway | `openrouter` by default, `ollama` for local Ollama experiments. |
-| `OPENROUTER_API_KEY` | Gateway | Required when using OpenRouter. Never commit a real key. |
+| `AI_PROVIDER` | Gateway | `mock` in local examples and CI, `openrouter` when unset in raw gateway startup, `ollama` for local Ollama experiments. |
+| `OPENROUTER_API_KEY` | Gateway | Required only when using OpenRouter. Never commit a real key. |
 | `OPENROUTER_MODEL` | Gateway | OpenRouter model name. Demo docs use `z-ai/glm-4.5-air:free` unless overridden. |
 | `OLLAMA_URL`, `OLLAMA_MODEL` | Gateway | Used only when `AI_PROVIDER=ollama`. |
 | `SERVER_WALLET_PRIVATE_KEY` | Gateway | Signs receipts. Use only unfunded local keys in development. |
@@ -348,7 +354,7 @@ Core local variables live in [.env.example](.env.example). Production placeholde
 | Verifier lint | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings` | Run for Rust changes. |
 | Web lint/build/typecheck | `cd web && bun run lint && bun run build && bun run test` | `bun run test` is `tsc --noEmit`. |
 | SDK typecheck/tests | `cd sdk/typescript && bun run typecheck && bun run test` | Covers signing parity, signed retry headers, receipt decoding, trusted-key receipt verification, and mocked client flow. |
-| E2E | `bun run test:e2e` | Starts gateway/verifier. Requires `OPENROUTER_API_KEY` for default OpenRouter startup path. |
+| E2E | `bun run test:e2e` | Starts gateway/verifier and defaults to the deterministic mock provider. |
 | All unit tests | `bun run test:unit` | Gateway plus verifier tests. |
 
 Do not use `bun test` by itself for the project E2E flow. It runs Bun's test runner without starting services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3001}
       - RECEIPT_STORE=${RECEIPT_STORE:-redis}
       - CHAIN_ID=${CHAIN_ID:-84532}
+      - AI_PROVIDER=${AI_PROVIDER:-mock}
       # Pass through from .env file
       - OPENROUTER_API_KEY
       - OPENROUTER_MODEL

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -68,7 +68,7 @@ The verifier route `POST /verify` is not a gateway route. It belongs to the inte
 | `cache.go` | Optional response cache. Cache hits still require valid payment verification. |
 | `ratelimit.go` | Token bucket implementation. |
 | `middleware.go` | Request timeout and correlation ID middleware. |
-| `internal/ai/` | OpenRouter and Ollama provider implementations. |
+| `internal/ai/` | Mock, OpenRouter, and Ollama provider implementations. |
 | `openapi.yaml` | Public gateway API contract. |
 
 ## Configuration
@@ -77,7 +77,7 @@ Required for normal OpenRouter gateway startup:
 
 | Variable | Notes |
 | --- | --- |
-| `OPENROUTER_API_KEY` | Required when `AI_PROVIDER` is unset or `openrouter`. |
+| `OPENROUTER_API_KEY` | Required when `AI_PROVIDER` is unset or `openrouter`. Not required for `AI_PROVIDER=mock` or `AI_PROVIDER=ollama`. |
 | `SERVER_WALLET_PRIVATE_KEY` | Required. Signs receipts. Use an unfunded development key locally. |
 | `REDIS_URL` | Required when `RECEIPT_STORE=redis` or `CACHE_ENABLED=true`. |
 
@@ -86,7 +86,7 @@ Common optional variables:
 | Variable | Default | Notes |
 | --- | --- | --- |
 | `PORT` | `3000` | Gateway listen port. |
-| `AI_PROVIDER` | `openrouter` | Supported values: `openrouter`, `ollama`. |
+| `AI_PROVIDER` | `openrouter` when unset; local scripts use `mock` | Supported values: `openrouter`, `mock`, `ollama`. |
 | `OPENROUTER_MODEL` | `z-ai/glm-4.5-air:free` in code/docs unless overridden | OpenRouter model. |
 | `OPENROUTER_URL` | `https://openrouter.ai/api/v1/chat/completions` provider default | Used by tests and custom OpenRouter-compatible endpoints. |
 | `OLLAMA_URL` | `http://localhost:11434` | Used when `AI_PROVIDER=ollama`. |
@@ -118,14 +118,18 @@ cp .env.example .env
 bun run stack
 ```
 
+The root stack script defaults the gateway to `AI_PROVIDER=mock`,
+`RECEIPT_STORE=memory`, and `CACHE_ENABLED=false` unless you exported different
+values. That path requires no OpenRouter key, Ollama server, or Redis instance.
+
 To run only the gateway:
 
 ```bash
 cd gateway
-RECEIPT_STORE=memory CACHE_ENABLED=false go run .
+AI_PROVIDER=mock RECEIPT_STORE=memory CACHE_ENABLED=false go run .
 ```
 
-The verifier must be reachable at `VERIFIER_URL` for signed requests. OpenRouter startup requires `OPENROUTER_API_KEY` unless `AI_PROVIDER=ollama`.
+The verifier must be reachable at `VERIFIER_URL` for signed requests. OpenRouter startup requires `OPENROUTER_API_KEY` unless `AI_PROVIDER=mock` or `AI_PROVIDER=ollama`. Use `AI_PROVIDER=mock` for deterministic local demos and CI runs with no model-provider network call.
 
 ## Testing
 

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestValidateConfig_MissingRequiredEnv(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "")
 	t.Setenv("VERIFIER_URL", "")
@@ -65,6 +66,7 @@ func TestNormalizeRecipientAddress(t *testing.T) {
 }
 
 func TestValidateConfig_WithRequiredEnv(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
@@ -78,7 +80,23 @@ func TestValidateConfig_WithRequiredEnv(t *testing.T) {
 	}
 }
 
+func TestValidateConfig_MockProviderDoesNotRequireOpenRouterKey(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "mock")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
+	t.Setenv("CACHE_ENABLED", "false")
+	t.Setenv("RECEIPT_STORE", "memory")
+	t.Setenv("REDIS_URL", "")
+	t.Setenv("RECIPIENT_ADDRESS", "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219")
+
+	if err := validateConfig(); err != nil {
+		t.Fatalf("expected mock provider to allow missing OPENROUTER_API_KEY, got: %v", err)
+	}
+}
+
 func TestValidateConfig_CacheEnabledRequiresRedis(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
@@ -98,6 +116,7 @@ func TestValidateConfig_CacheEnabledRequiresRedis(t *testing.T) {
 }
 
 func TestValidateConfig_CacheEnabledWithValidRedis(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
@@ -113,6 +132,7 @@ func TestValidateConfig_CacheEnabledWithValidRedis(t *testing.T) {
 }
 
 func TestValidateConfig_DefaultReceiptStoreRequiresRedis(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
@@ -131,6 +151,7 @@ func TestValidateConfig_DefaultReceiptStoreRequiresRedis(t *testing.T) {
 }
 
 func TestValidateConfig_MemoryReceiptStoreDoesNotRequireRedis(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")
@@ -146,6 +167,7 @@ func TestValidateConfig_MemoryReceiptStoreDoesNotRequireRedis(t *testing.T) {
 }
 
 func TestValidateConfig_InvalidReceiptStoreMode(t *testing.T) {
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("OPENROUTER_API_KEY", "test-key")
 	t.Setenv("SERVER_WALLET_PRIVATE_KEY", "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
 	t.Setenv("VERIFIER_URL", "http://127.0.0.1:3002")

--- a/gateway/docker_compose_test.go
+++ b/gateway/docker_compose_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestDockerComposeGatewayPassesAIProvider(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "docker-compose.yml"))
+	require.NoError(t, err)
+
+	var compose struct {
+		Services map[string]struct {
+			Environment []string `yaml:"environment"`
+		} `yaml:"services"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &compose))
+
+	gatewayService, ok := compose.Services["gateway"]
+	require.True(t, ok, "docker-compose.yml must define the gateway service")
+	require.Contains(t, gatewayService.Environment, "AI_PROVIDER=${AI_PROVIDER:-mock}")
+}

--- a/gateway/internal/ai/mock.go
+++ b/gateway/internal/ai/mock.go
@@ -1,0 +1,30 @@
+package ai
+
+import (
+	"context"
+	"strings"
+)
+
+// MockProvider returns deterministic summaries for local demos and CI.
+type MockProvider struct{}
+
+// NewMockProvider creates a deterministic provider with no external dependencies.
+func NewMockProvider() *MockProvider {
+	return &MockProvider{}
+}
+
+// Generate returns a stable summary without calling a model provider.
+func (p *MockProvider) Generate(ctx context.Context, text string) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	normalized := strings.Join(strings.Fields(text), " ")
+	if normalized == "" {
+		return "Mock summary: no input text provided.", nil
+	}
+	if len(normalized) > 96 {
+		normalized = strings.TrimSpace(normalized[:96]) + "..."
+	}
+	return "Mock summary: " + normalized, nil
+}

--- a/gateway/internal/ai/provider.go
+++ b/gateway/internal/ai/provider.go
@@ -12,8 +12,8 @@ type Provider interface {
 	Generate(ctx context.Context, prompt string) (string, error)
 }
 
-// NewProvider creates an AI provider based on the AI_PROVIDER environment variable
-// Supported providers: "openrouter" (default), "ollama"
+// NewProvider creates an AI provider based on the AI_PROVIDER environment variable.
+// Supported providers: "openrouter" (default), "mock", "ollama".
 func NewProvider() (Provider, error) {
 	providerType := os.Getenv("AI_PROVIDER")
 	if providerType == "" {
@@ -23,6 +23,8 @@ func NewProvider() (Provider, error) {
 	switch providerType {
 	case "openrouter":
 		return NewOpenRouterProvider(), nil
+	case "mock":
+		return NewMockProvider(), nil
 	case "ollama":
 		return NewOllamaProvider(), nil
 	default:

--- a/gateway/internal/ai/provider_test.go
+++ b/gateway/internal/ai/provider_test.go
@@ -30,6 +30,12 @@ func TestNewProvider(t *testing.T) {
 			wantErr:      false,
 		},
 		{
+			name:         "mock provider",
+			providerType: "mock",
+			wantType:     "*ai.MockProvider",
+			wantErr:      false,
+		},
+		{
 			name:         "unsupported provider",
 			providerType: "invalid",
 			wantType:     "",
@@ -70,8 +76,32 @@ func TestNewProvider(t *testing.T) {
 				if _, ok := provider.(*OllamaProvider); !ok {
 					t.Errorf("NewProvider() returned %T, want *OllamaProvider", provider)
 				}
+			case "*ai.MockProvider":
+				if _, ok := provider.(*MockProvider); !ok {
+					t.Errorf("NewProvider() returned %T, want *MockProvider", provider)
+				}
 			}
 		})
+	}
+}
+
+func TestMockProviderGenerateIsDeterministic(t *testing.T) {
+	provider := NewMockProvider()
+
+	first, err := provider.Generate(t.Context(), "This is a long document about agent payments.")
+	if err != nil {
+		t.Fatalf("Generate returned error: %v", err)
+	}
+	second, err := provider.Generate(t.Context(), "This is a long document about agent payments.")
+	if err != nil {
+		t.Fatalf("Generate returned error on second call: %v", err)
+	}
+
+	if first != second {
+		t.Fatalf("mock provider should be deterministic, first %q second %q", first, second)
+	}
+	if first == "" {
+		t.Fatal("mock provider returned empty summary")
 	}
 }
 

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -241,10 +241,13 @@ func main() {
 		fmt.Printf("    - Port: %s\n", port)
 	}
 	modelKey := "OPENROUTER_MODEL"
-	if providerType == "ollama" {
+	if providerType == "mock" {
+		modelKey = ""
+	} else if providerType == "ollama" {
 		modelKey = "OLLAMA_MODEL"
 	}
-	if model := os.Getenv(modelKey); model != "" {
+	if modelKey != "" && os.Getenv(modelKey) != "" {
+		model := os.Getenv(modelKey)
 		fmt.Printf("    - %s: %s\n", modelKey, model)
 	}
 	if verifier := os.Getenv("VERIFIER_URL"); verifier != "" {
@@ -256,7 +259,7 @@ func main() {
 	if os.Getenv("PORT") == "" {
 		fmt.Println("[WARN] PORT not set, using default: 3000")
 	}
-	if os.Getenv(modelKey) == "" {
+	if modelKey != "" && os.Getenv(modelKey) == "" {
 		fmt.Printf("[WARN] %s not set, using provider default model\n", modelKey)
 	}
 	if os.Getenv("CHAIN_ID") == "" {
@@ -976,6 +979,9 @@ func handleReadyz(c *gin.Context) {
 	case "openrouter":
 		aiStatus = checkOpenRouterHealth()
 		checks["openrouter"] = aiStatus
+	case "mock":
+		aiStatus = "ok"
+		checks["mock"] = aiStatus
 	case "ollama":
 		aiStatus = checkOllamaHealth()
 		checks["ollama"] = aiStatus

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -383,6 +383,7 @@ func TestHandleHealthz(t *testing.T) {
 
 func TestHandleReadyz_Healthy(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	t.Setenv("AI_PROVIDER", "openrouter")
 	t.Setenv("RECEIPT_STORE", "memory")
 	t.Setenv("CACHE_ENABLED", "false")
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "x402-style API monetization layer",
   "scripts": {
-    "stack": "concurrently -n \"VERIFIER,GATEWAY,WEB\" -c \"red,cyan,green\" \"cd verifier && cargo run\" \"cd gateway && RECEIPT_STORE=${RECEIPT_STORE:-memory} CACHE_ENABLED=${CACHE_ENABLED:-false} go run .\" \"cd web && bun run dev\"",
+    "stack": "concurrently -n \"VERIFIER,GATEWAY,WEB\" -c \"red,cyan,green\" \"cd verifier && cargo run\" \"cd gateway && RECEIPT_STORE=${RECEIPT_STORE:-memory} CACHE_ENABLED=${CACHE_ENABLED:-false} AI_PROVIDER=${AI_PROVIDER:-mock} go run .\" \"cd web && bun run dev\"",
     "test:unit": "cd gateway && go test ./... && cd ../verifier && cargo test",
     "test:go": "cd gateway && go test ./...",
     "test:rust": "cd verifier && cargo test",

--- a/run_e2e.sh
+++ b/run_e2e.sh
@@ -15,29 +15,71 @@ cleanup() {
 
 trap cleanup EXIT
 
+export RECEIPT_STORE="${RECEIPT_STORE:-memory}"
+export CACHE_ENABLED="${CACHE_ENABLED:-false}"
+export AI_PROVIDER="${AI_PROVIDER:-mock}"
+# Deterministic fixture values for local/CI E2E only. Real deployments must
+# provide their own receipt signing key and recipient.
+export SERVER_WALLET_PRIVATE_KEY="${SERVER_WALLET_PRIVATE_KEY:-0123456789012345678901234567890123456789012345678901234567890123}"
+export RECIPIENT_ADDRESS="${RECIPIENT_ADDRESS:-0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219}"
+export CHAIN_ID="${CHAIN_ID:-84532}"
+export EXPECTED_CHAIN_ID="${EXPECTED_CHAIN_ID:-84532}"
+
+wait_for_service() {
+    local name="$1"
+    local url="$2"
+    local pid="$3"
+    local attempts="${4:-30}"
+    local attempt=1
+
+    while [ "$attempt" -le "$attempts" ]; do
+        if curl -fsS "$url" >/dev/null 2>&1; then
+            echo "$name is ready"
+            return 0
+        fi
+
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "$name exited before becoming ready"
+            return 1
+        fi
+
+        sleep 1
+        attempt=$((attempt + 1))
+    done
+
+    echo "$name did not become ready at $url"
+    return 1
+}
+
 echo "Building Verifier..."
 cd "$SCRIPT_DIR/verifier" && cargo build --quiet
 if [ $? -ne 0 ]; then
     echo "Verifier build failed"
     exit 1
 fi
+
+echo "Building Gateway..."
+cd "$SCRIPT_DIR/gateway" && go build -o gateway .
+if [ $? -ne 0 ]; then
+    echo "Gateway build failed"
+    exit 1
+fi
+
 echo "Starting Verifier..."
-cargo run --quiet &
+"$SCRIPT_DIR/verifier/target/debug/verifier" &
 VERIFIER_PID=$!
 
 echo "Starting Gateway..."
 cd "$SCRIPT_DIR/gateway"
-export RECEIPT_STORE="${RECEIPT_STORE:-memory}"
-export CACHE_ENABLED="${CACHE_ENABLED:-false}"
 # The gateway now requires VERIFIER_URL at startup; point it at the verifier
 # we just spawned on localhost above. Honors any caller-supplied override.
 export VERIFIER_URL="${VERIFIER_URL:-http://127.0.0.1:3002}"
-go run . &
+./gateway &
 GATEWAY_PID=$!
 
-# Wait for services to be ready
-echo "Waiting for services to initialize (10s)..."
-sleep 10
+echo "Waiting for services to initialize..."
+wait_for_service "Verifier" "http://127.0.0.1:3002/health" "$VERIFIER_PID" || exit 1
+wait_for_service "Gateway" "http://127.0.0.1:3000/healthz" "$GATEWAY_PID" || exit 1
 
 echo "Running E2E Tests..."
 cd "$SCRIPT_DIR" || { echo "Error: Failed to change directory to $SCRIPT_DIR"; exit 1; }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -83,6 +83,16 @@ cd sdk/typescript
 bun run examples/summarize.ts "Text to summarize"
 ```
 
+Verify a receipt by ID or by a base64 `X-402-Receipt` header value:
+
+```bash
+cd sdk/typescript
+PAYGATE_SERVER_PUBLIC_KEY=0x... PAYGATE_GATEWAY_URL=http://localhost:3000 bun run examples/verify-receipt.ts rcpt_...
+```
+
+Receipt verification needs `PAYGATE_SERVER_PUBLIC_KEY` as the trust anchor. The
+SDK does not trust the public key embedded inside the receipt by itself.
+
 ## Optional Live Test
 
 The live SDK test is skipped by default. Start the local stack first:

--- a/sdk/typescript/examples/verify-receipt.ts
+++ b/sdk/typescript/examples/verify-receipt.ts
@@ -1,0 +1,39 @@
+import { decodeReceiptHeader, fetchReceipt, verifyReceipt, type SignedReceipt } from "../src";
+
+const gatewayUrl = process.env.PAYGATE_GATEWAY_URL ?? "http://localhost:3000";
+const trustedServerPublicKey = process.env.PAYGATE_SERVER_PUBLIC_KEY;
+const receiptInput = process.argv[2];
+
+if (!trustedServerPublicKey) {
+  throw new Error("Set PAYGATE_SERVER_PUBLIC_KEY to the trusted gateway receipt signing key.");
+}
+
+if (!receiptInput) {
+  throw new Error("Pass a receipt ID like rcpt_... or a base64 X-402-Receipt header value.");
+}
+
+async function loadReceipt(input: string): Promise<SignedReceipt> {
+  if (input.startsWith("rcpt_")) {
+    const receipt = await fetchReceipt(input, gatewayUrl);
+    if (receipt === null) {
+      throw new Error(`Receipt ${input} was not found at ${gatewayUrl}.`);
+    }
+    return receipt;
+  }
+
+  return decodeReceiptHeader(input);
+}
+
+const receipt = await loadReceipt(receiptInput);
+const verified = await verifyReceipt(receipt, {
+  expectedServerPublicKey: trustedServerPublicKey,
+});
+
+console.log("Receipt ID:", receipt.receipt.id);
+console.log("Payer:", receipt.receipt.payment.payer);
+console.log("Endpoint:", receipt.receipt.service.endpoint);
+console.log("Receipt verified:", verified);
+
+if (!verified) {
+  throw new Error("Receipt signature did not verify against PAYGATE_SERVER_PUBLIC_KEY.");
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,14 +17,14 @@ The `tests/` directory contains Bun end-to-end coverage for the gateway and veri
 - Go toolchain
 - Rust toolchain
 - Ports `3000` and `3002` free
-- `OPENROUTER_API_KEY` for the default OpenRouter gateway startup path
 
 The helper defaults to:
 
+- `AI_PROVIDER=mock`
 - `RECEIPT_STORE=memory`
 - `CACHE_ENABLED=false`
 
-Redis is not required unless you override those variables.
+OpenRouter, Ollama, and Redis are not required unless you override those variables.
 
 ## Run
 
@@ -77,7 +77,7 @@ Use only unfunded local or test wallet keys for live SDK tests. `PAYGATE_SERVER_
 
 ## Reading Failures
 
-The signed request may return `502 upstream_unavailable` or `504 upstream_timeout` after payment verification succeeds if OpenRouter is unavailable or slow. That usually means the x402 verification path passed and only the upstream AI call failed.
+The default E2E path uses the deterministic mock provider and should return `200` for the first signed request. If you override `AI_PROVIDER=openrouter` or `AI_PROVIDER=ollama`, provider failures can still surface as `502 upstream_unavailable` or `504 upstream_timeout` after payment verification succeeds.
 
 Failures that usually indicate payment-flow regressions:
 

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -75,19 +75,10 @@ describe("MicroAI Paygate E2E Flow", () => {
       body: JSON.stringify({ text: "This is a test text to summarize." }),
     });
 
-    // Note: It might fail if OpenRouter credentials are missing/invalid, but we expect at least not 402/403.
-    // If 502 with upstream_unavailable, it means verification passed and only the AI provider failed.
-    if (res.status === 502) {
-        const text = await res.text();
-        if (text.includes("upstream_unavailable")) {
-            expect(true).toBe(true); 
-            return;
-        }
-    }
-
     expect(res.status).toBe(200);
     const data = await res.json() as any;
-    expect(data.result).toBeDefined();
+    expect(data.result).toStartWith("Mock summary:");
+    expect(res.headers.get("X-402-Receipt")).toBeTruthy();
   }, 30000);
 
   it("should reject replayed signed payment context", async () => {
@@ -113,14 +104,7 @@ describe("MicroAI Paygate E2E Flow", () => {
       body,
     });
 
-    if (first.status === 504) {
-      const text = await first.text();
-      if (!text.includes("upstream_timeout")) {
-        throw new Error(`expected upstream_timeout for 504, got ${text}`);
-      }
-    } else if (first.status !== 200 && first.status !== 502) {
-      throw new Error(`expected first signed request to pass verification, got ${first.status}: ${await first.text()}`);
-    }
+    expect(first.status).toBe(200);
 
     const second = await fetch(`${GATEWAY_URL}/api/ai/summarize`, {
       method: "POST",


### PR DESCRIPTION
## Summary

- Add deterministic `AI_PROVIDER=mock` support for local and CI payment-flow runs.
- Default `bun run stack` and `bun run test:e2e` to the mock provider so the 402 challenge/sign/retry/receipt path runs without OpenRouter, Ollama, Redis, or secrets.
- Update E2E, CI, and docs around the deterministic flow, plus add an SDK receipt verification example.

## Why

The E2E workflow should exercise the payment flow consistently in CI instead of depending on live model-provider credentials. Docs now also avoid implying Redis-backed verifier nonce storage exists today; verifier replay protection remains single-process memory until a shared nonce store is implemented.

## CI fix

The E2E workflow dependency prep now runs Go and Rust commands from their service directories:

- `cd gateway && go mod download`
- `cd verifier && cargo fetch`

## Validation

- `git diff --check`
- `cd gateway && go test -v ./...`
- `cd gateway && go vet ./...`
- `cd sdk/typescript && bun run typecheck`
- `cd sdk/typescript && bun run test`
- `bun run test:e2e`
- `(cd gateway && go mod download) && (cd verifier && cargo fetch)`