### PR TITLE
docs: add SDK receipt verification example

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -133,6 +133,7 @@ Run the receipt verification example:
 ```bash
 cd sdk/typescript
 bun run examples/verify-receipt.ts "Text to summarize"
+```
 
 ## Optional Live Test
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -83,6 +83,57 @@ cd sdk/typescript
 bun run examples/summarize.ts "Text to summarize"
 ```
 
+## Receipt Verification Example
+
+Receipt verification with a trusted public key (replace the placeholder with the gateway's real public key):
+
+```ts
+import { ethers } from "ethers";
+import { PaygateClient, PaygateSdkError } from "@microai/paygate-sdk";
+
+async function main(): Promise<void> {
+  const client = new PaygateClient({
+    gatewayUrl: process.env.PAYGATE_GATEWAY_URL ?? "http://localhost:3000",
+    signer: new ethers.Wallet(process.env.EVM_PRIVATE_KEY!),
+    trustedServerPublicKey: process.env.PAYGATE_SERVER_PUBLIC_KEY ?? "0xYOUR_GATEWAY_PUBLIC_KEY",
+  });
+
+  try {
+    const response = await client.summarize("Text to summarize");
+
+    if (!response.receipt) {
+      console.warn("No receipt returned; treat the response as untrusted.");
+      return;
+    }
+
+    if (!response.receiptVerified) {
+      console.warn("Receipt was present but did not verify; discard the response.");
+      return;
+    }
+
+    console.log("Verified receipt ID:", response.receipt.receipt.id);
+    console.log("Summary:", response.data.result);
+  } catch (error) {
+    if (
+      error instanceof PaygateSdkError &&
+      (error.code === "receipt_verification_failed" || error.code === "receipt_decode_failed")
+    ) {
+      console.error("Receipt verification failed; treat the response as untrusted.");
+      return;
+    }
+    throw error;
+  }
+}
+
+await main();
+```
+
+Run the receipt verification example:
+
+```bash
+cd sdk/typescript
+bun run examples/verify-receipt.ts "Text to summarize"
+
 ## Optional Live Test
 
 The live SDK test is skipped by default. Start the local stack first:

--- a/sdk/typescript/examples/verify-receipt.ts
+++ b/sdk/typescript/examples/verify-receipt.ts
@@ -1,0 +1,52 @@
+import { ethers } from "ethers";
+import { PaygateClient, PaygateSdkError } from "../src";
+
+async function main(): Promise<void> {
+  const gatewayUrl = process.env.PAYGATE_GATEWAY_URL ?? "http://localhost:3000";
+  const privateKey = process.env.EVM_PRIVATE_KEY;
+  const trustedServerPublicKey =
+    process.env.PAYGATE_SERVER_PUBLIC_KEY ?? "0xYOUR_GATEWAY_PUBLIC_KEY";
+
+  if (!privateKey) {
+    throw new Error("Set EVM_PRIVATE_KEY to an unfunded local or test wallet private key.");
+  }
+
+  if (trustedServerPublicKey === "0xYOUR_GATEWAY_PUBLIC_KEY") {
+    throw new Error("Set PAYGATE_SERVER_PUBLIC_KEY to the trusted gateway public key.");
+  }
+
+  const text = process.argv.slice(2).join(" ") || "Summarize MicroAI Paygate in one sentence.";
+  const signer = new ethers.Wallet(privateKey);
+  const client = new PaygateClient({ gatewayUrl, signer, trustedServerPublicKey });
+
+  try {
+    const response = await client.summarize(text);
+
+    if (!response.receipt) {
+      console.warn("No receipt returned; treat the response as untrusted.");
+      process.exitCode = 1;
+      return;
+    }
+
+    if (!response.receiptVerified) {
+      console.warn("Receipt was present but did not verify; discard the response.");
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log("Summary:", response.data.result);
+    console.log("Verified receipt ID:", response.receipt.receipt.id);
+  } catch (error) {
+    if (
+      error instanceof PaygateSdkError &&
+      (error.code === "receipt_verification_failed" || error.code === "receipt_decode_failed")
+    ) {
+      console.error("Receipt verification failed; treat the response as untrusted.");
+      process.exitCode = 1;
+      return;
+    }
+    throw error;
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

Adds a receipt verification example for the TypeScript SDK.

## Changes

* Added a Receipt Verification Example section to `sdk/typescript/README.md`
* Added `examples/verify-receipt.ts`
* Demonstrated handling for:

  * verified receipts
  * missing receipts
  * receipt verification failures
* Added trusted public key configuration example

## Validation

* `bun run typecheck` ✅
* `bun run test` ✅ (20 passed, 1 skipped)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a receipt verification guide to the TypeScript SDK README covering how to validate receipts, enforce trust, and handle verification failures.

* **New Features**
  * Added an example script demonstrating a secure receipt-verification workflow, with proper trust checks, error handling for verification/decode failures, and guidance for running the example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->