### PR TITLE
ci(web): enforce typecheck in web CI and clarify verification commands

### DIFF
--- a/.github/workflows/web-lint-build.yml
+++ b/.github/workflows/web-lint-build.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: web
         run: bun run lint
 
+      - name: Typecheck (tsc)
+        working-directory: web
+        run: bun run typecheck
+
       - name: Unit tests (Bun)
         working-directory: web
         run: bun run test:unit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,7 @@ Run the checks for the area you touched. When a change crosses services, run eve
 | --- | --- |
 | `gateway/**` | `cd gateway && gofmt -w . && go test -v ./... && go vet ./...` |
 | `verifier/**` | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test` |
-| `web/**` | `cd web && bun run lint && bun run build && bun run test` |
+| `web/**` | `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` |
 | `sdk/typescript/**` | `cd sdk/typescript && bun run typecheck && bun run test` |
 | `tests/**` or x402 flow | `bun run test:e2e` when `OPENROUTER_API_KEY` is available |
 | `gateway/openapi.yaml` | YAML parse plus compare against gateway routes |

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ build: build-gateway build-verifier build-web
 test:
 	cd gateway && go test -v ./...
 	cd verifier && cargo test
-	cd web && bun run test
+	cd web && bun run typecheck
+	cd web && bun run test:unit
 
 lint:
 	cd gateway && go vet ./...

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Core local variables live in [.env.example](.env.example). Production placeholde
 | Gateway vet | `cd gateway && go vet ./...` | Run for Go changes. |
 | Verifier tests | `cd verifier && cargo test` | Covers EIP-712, chain ID, timestamp, and nonce behavior. |
 | Verifier lint | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings` | Run for Rust changes. |
-| Web lint/build/typecheck/unit | `cd web && bun run lint && bun run build && bun run test && bun run test:unit` | `bun run test` is `tsc --noEmit`; `bun run test:unit` runs Bun unit tests. |
+| Web lint/build/typecheck/unit | `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` | `bun run typecheck` is `tsc --noEmit` (`bun run test` is kept as an alias); `bun run test:unit` runs Bun unit tests. |
 | SDK typecheck/tests | `cd sdk/typescript && bun run typecheck && bun run test` | Covers signing parity, signed retry headers, receipt decoding, trusted-key receipt verification, and mocked client flow. |
 | E2E | `bun run test:e2e` | Starts gateway/verifier. Requires `OPENROUTER_API_KEY` for default OpenRouter startup path. |
 | All unit tests | `bun run test:unit` | Gateway plus verifier tests. |

--- a/web/README.md
+++ b/web/README.md
@@ -74,12 +74,12 @@ The documentation site is available at `http://localhost:3001/docs`.
 ```bash
 cd web
 bun run lint
-bun run build
-bun run test
+bun run typecheck
 bun run test:unit
+bun run build
 ```
 
-`bun run test` runs `tsc --noEmit`. `bun run test:unit` runs the Bun unit tests.
+`bun run typecheck` runs `tsc --noEmit` (`bun run test` is kept as an alias for it). `bun run test:unit` runs the Bun unit tests. CI runs these same checks via `.github/workflows/web-lint-build.yml`.
 
 ## Deployment Notes
 

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "bun run typecheck",
     "test:unit": "bun test"
   },
   "dependencies": {

--- a/web/src/app/docs/operations/page.mdx
+++ b/web/src/app/docs/operations/page.mdx
@@ -33,7 +33,7 @@ cd gateway && go vet ./...
 cd verifier && cargo test
 cd verifier && cargo fmt -- --check
 cd verifier && cargo clippy -- -D warnings
-cd web && bun run lint && bun run build && bun run test
+cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build
 cd sdk/typescript && bun run typecheck && bun run test
 bun run test:e2e
 bun run test:unit


### PR DESCRIPTION
Closes #173.

## Problem
The web CI workflow (`web-lint-build.yml`) ran lint, Bun unit tests, and build, but **never ran the TypeScript check** — so `tsc` errors in `web/` could merge. The web `test` script (`tsc --noEmit`) was also easy to confuse with the unit tests now that `test:unit` exists.

## Changes
- **`web/package.json`**: add an explicit `typecheck` script (`tsc --noEmit`); keep `test` as an alias (`bun run typecheck`) so existing references stay valid. `test:unit` unchanged.
- **`.github/workflows/web-lint-build.yml`**: add a `Typecheck (tsc)` step. Web CI now runs **lint → typecheck → unit tests → build**.
- **Docs** (`README.md`, `web/README.md`, `CONTRIBUTING.md`): update the web verification commands to the clearer `bun run typecheck` / `bun run test:unit`.

## Acceptance criteria
- [x] Web workspace has an explicit Bun unit-test command (`bun run test:unit`).
- [x] TypeScript check has a clear command (`bun run typecheck`) and still runs successfully.
- [x] Web CI runs lint, build, typecheck, and Bun unit tests.
- [x] Existing web tests pass without wallet/gateway/verifier/Redis/OpenRouter secrets.
- [x] Contributor docs updated to use the new commands.

Non-goals respected: no gateway/verifier behavior changes, no wallet/payment changes, Bun-only (no npm).

## Tests run (local, Bun 1.3.14)
- `cd web && bun run typecheck` → passes (exit 0)
- `cd web && bun run test:unit` → `35 pass, 0 fail` across 3 files
- `cd web && bun run lint` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testing and build instructions across developer documentation to reflect the streamlined build and testing process.

* **Chores**
  * Enhanced CI/CD workflows and development processes to include additional code quality verification steps in the build pipeline.
  * Reorganized development command structure for improved build consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->