### PR TITLE
Clarify Redis deployment docs for verifier nonce replay protection  

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -9,7 +9,7 @@ Free-tier deployment of MicroAI Paygate across three platforms. Total recurring 
 | `verifier/` (Rust) | Render Web Service | Free | Public over HTTPS; stateless EIP-712 recovery |
 | `gateway/` (Go) | Render Web Service | Free | Public; calls verifier and OpenRouter, talks to Redis |
 | `web/` (Next.js) | Vercel | Hobby | Built from `web/` subdirectory |
-| Redis | Upstash | Free | Receipt store + nonce replay protection |
+| Redis | Upstash | Free | Receipt store + optional gateway cache. Verifier nonce replay protection is currently in-memory on one verifier process. |
 
 Both Render services share a region for low inter-service latency. Both **sleep after 15 minutes of inactivity** — the first request after sleep takes 30–50 seconds while the containers wake. The web app shows a warm-up banner during this window. See [Cold-start behavior](#cold-start-behavior) for details.
 
@@ -49,6 +49,8 @@ Quick sanity check:
 ```sh
 redis-cli -u 'rediss://default:...@...upstash.io:6379' PING   # should print PONG
 ```
+
+> Note: Upstash is used for gateway receipt persistence and optional cache behavior. The verifier still uses in-memory nonce replay protection in the current implementation, so production verifier scaling requires a shared nonce store before running multiple verifier replicas.
 
 ## 2. Deploy the Verifier on Render
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 The backend services (gateway + verifier) are hosted on Render's free tier and **sleep after 15 minutes of inactivity**. The first request after a quiet period takes 30–50 seconds while both services wake. The web UI shows a brief warm-up banner during this window. Subsequent requests are normal speed.
 
-The deployed stack is **Render** (Rust verifier + Go gateway) + **Vercel** (Next.js web) + **Upstash** (Redis for nonces and signed receipts). All on free tiers — total recurring cost is $0. See [DEPLOY.md](DEPLOY.md) for the step-by-step deployment guide.
+The deployed stack is **Render** (Rust verifier + Go gateway) + **Vercel** (Next.js web) + **Upstash** (Redis for signed receipts and optional gateway cache). Verifier nonce replay protection is still in memory on the single verifier process, so multi-instance verifier deployments need shared nonce storage. All on free tiers — total recurring cost is $0. See [DEPLOY.md](DEPLOY.md) for the step-by-step deployment guide.
 
 The demo runs on **Base Sepolia testnet**. A valid EIP-712 signature proves wallet authorization for the payment context; it does not move USDC on-chain. Bring a wallet on Base Sepolia to try the full sign-and-summarize flow.
 


### PR DESCRIPTION
solve issue no #174 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment and live demo documentation to clarify Upstash Redis usage: provides signed receipt storage and optional gateway response caching.
  * Added clarification that verifier nonce replay protection currently operates in-memory on a single process, and noted that production scaling to multiple replicas would require a shared nonce store implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->