### PR TITLE
test: add docs navigation route consistency test

### DIFF
--- a/web/src/components/docs/docs-nav.test.ts
+++ b/web/src/components/docs/docs-nav.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from "node:fs";
+import { readdirSync, statSync } from "node:fs";
 import { describe, expect, it } from "bun:test";
 import { DOCS_NAV_ITEMS } from "./docs-nav";
 
@@ -25,12 +25,11 @@ describe("docs navigation", () => {
   const docsEntries = readdirSync("./src/app/docs");
 
   const docsRoutes = docsEntries
-    .filter(
-      (entry) =>
-        !["page.mdx", "layout.tsx"].includes(entry)
-    )
-    .map((entry) => `/docs/${entry}`)
-    .sort();
+  .filter((entry) =>
+    statSync(`./src/app/docs/${entry}`).isDirectory()
+  )
+  .map((entry) => `/docs/${entry}`)
+  .sort();
 
   const navRoutes = DOCS_NAV_ITEMS.map((item) => item.href)
     .filter((href) => href !== "/docs")

--- a/web/src/components/docs/docs-nav.test.ts
+++ b/web/src/components/docs/docs-nav.test.ts
@@ -1,3 +1,4 @@
+import { readdirSync } from "node:fs";
 import { describe, expect, it } from "bun:test";
 import { DOCS_NAV_ITEMS } from "./docs-nav";
 
@@ -19,4 +20,22 @@ describe("docs navigation", () => {
     expect(new Set(DOCS_NAV_ITEMS.map((item) => item.href)).size).toBe(DOCS_NAV_ITEMS.length);
     expect(new Set(DOCS_NAV_ITEMS.map((item) => item.label)).size).toBe(DOCS_NAV_ITEMS.length);
   });
+
+  it("keeps docs navigation routes in sync with docs pages", () => {
+  const docsEntries = readdirSync("./src/app/docs");
+
+  const docsRoutes = docsEntries
+    .filter(
+      (entry) =>
+        !["page.mdx", "layout.tsx"].includes(entry)
+    )
+    .map((entry) => `/docs/${entry}`)
+    .sort();
+
+  const navRoutes = DOCS_NAV_ITEMS.map((item) => item.href)
+    .filter((href) => href !== "/docs")
+    .sort();
+
+  expect(navRoutes).toEqual(docsRoutes);
+});
 });


### PR DESCRIPTION
## Summary

Adds a test that verifies docs navigation routes stay synchronized with the actual docs pages in src/app/docs.

The test reads the filesystem, filters out page.mdx and layout.tsx, generates expected routes, and compares them with DOCS_NAV_ITEMS.

## Type Of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ x] Tests
- [ ] Refactor
- [ ] Deployment/config

## Affected Areas

- [ ] Gateway (`gateway/`)
- [ ] Verifier (`verifier/`)
- [ x] Web (`web/`)
- [ ] E2E/tests (`tests/`, `run_e2e.sh`)
- [ ] Benchmarks (`bench/`)
- [ ] Deployment/config (`deploy/`, Docker, env, workflows)
- [ ] Documentation/community files

## Contributor Checklist

- [x ] I kept the change focused and avoided unrelated refactors.
- [ ] I updated README/service docs/OpenAPI/env examples when behavior, config, headers, status codes, or public APIs changed.
- [ x] I did not commit secrets, private keys, funded wallets, API keys, or real production URLs.
- [ ] I checked x402/EIP-712 field parity when touching payment context, signatures, timestamps, nonces, chain IDs, receipts, or wallet flow.
- [ ] I checked Docker/Compose/Fly/Vercel docs when touching ports, service names, health checks, or environment variables.

## Verification

```text
cd web
bun test

Result:
36 pass
0 fail
Ran 36 tests across 3 files
```

Fixes #176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validating that documentation navigation items correspond to the expected filesystem routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnkanMisra/MicroAI-Paygate/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->