### PR TITLE
fix(server): add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -18,7 +18,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"runtime"
+	"syscall"
 	"strconv"
 	"strings"
 	"sync"
@@ -378,8 +380,33 @@ func main() {
 		port = "3000"
 	}
 
-	log.Printf("Go Gateway running on port %s", port)
-	r.Run(":" + port)
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: r,
+	}
+
+	go func() {
+		log.Printf("Go Gateway listening on port %s", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	log.Printf("Signal %s received, shutting down (max 30s)...", sig)
+
+	cleanupCancel()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Server forced to shutdown: %v", err)
+	} else {
+		log.Println("Server stopped gracefully")
+	}
 }
 
 // handleSummarize handles POST /api/ai/summarize requests. It validates


### PR DESCRIPTION
Handles SIGTERM and SIGINT so in-flight requests complete before the server stops. Uses a 30-second timeout, matching Docker's default SIGTERM-to-SIGKILL window. Also calls cleanupCancel to shut down the receipt cleanup goroutine cleanly.

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved graceful shutdown handling for the gateway service to better manage system termination signals and resource cleanup, reducing potential data loss during shutdown events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->