### PR TITLE
fix(gateway): add graceful shutdown on SIGTERM/SIGINT

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -18,10 +18,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -378,8 +380,33 @@ func main() {
 		port = "3000"
 	}
 
-	log.Printf("Go Gateway running on port %s", port)
-	r.Run(":" + port)
+	srv := &http.Server{
+		Addr:    ":" + port,
+		Handler: r,
+	}
+
+	go func() {
+		log.Printf("Go Gateway listening on port %s", port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server failed: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+	log.Printf("Signal %s received, shutting down (max 30s)...", sig)
+
+	cleanupCancel()
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("Server forced to shutdown: %v", err)
+	} else {
+		log.Println("Server stopped gracefully")
+	}
 }
 
 // handleSummarize handles POST /api/ai/summarize requests. It validates

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -397,6 +397,8 @@ func main() {
 	sig := <-quit
 	log.Printf("Signal %s received, shutting down (max 30s)...", sig)
 
+	signal.Stop(quit)
+
 	cleanupCancel()
 
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -385,17 +385,24 @@ func main() {
 		Handler: r,
 	}
 
+	startupErrCh := make(chan error, 1)
 	go func() {
 		log.Printf("Go Gateway listening on port %s", port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("Server failed: %v", err)
+			startupErrCh <- err
 		}
 	}()
 
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	sig := <-quit
-	log.Printf("Signal %s received, shutting down (max 30s)...", sig)
+
+	select {
+	case sig := <-quit:
+		log.Printf("Signal %s received, shutting down (max 30s)...", sig)
+	case err := <-startupErrCh:
+		log.Printf("Server failed to start: %v", err)
+		return
+	}
 
 	signal.Stop(quit)
 


### PR DESCRIPTION
## Summary

Handles SIGTERM and SIGINT so in-flight requests complete before the server stops.

## Changes

- Listens for SIGTERM and SIGINT via signal.Notify
- Stops accepting new connections on shutdown signal
- Waits for in-flight requests to complete (30s timeout)
- Logs shutdown progress at each stage
- Calls cleanupCancel to terminate receipt cleanup goroutine

## Validation

```
cd gateway && gofmt -w . && go vet ./... && go test -v ./...

```

All checks pass.

Closes #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented graceful shutdown handling for the HTTP server. The server now responds to termination signals by cleanly closing active connections with a 30-second timeout before forcing shutdown, improving application stability during restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->