### PR TITLE
[codex] add GitHub repo automation workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,68 @@
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "gateway/**"
+          - "deploy/fly/gateway.fly.toml"
+
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "verifier/**"
+
+TypeScript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "web/**"
+          - "sdk/typescript/**"
+          - "tests/**/*.ts"
+          - "tests/**/*.tsx"
+          - "package.json"
+          - "bun.lock"
+          - "tsconfig.json"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "gateway/openapi.yaml"
+          - ".env.example"
+          - ".env.production.example"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/pull_request_template.md"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/dependabot.yml"
+          - ".github/pull_request_template.md"
+
+type:docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "gateway/openapi.yaml"
+          - ".env.example"
+          - ".env.production.example"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/pull_request_template.md"
+
+type:devops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "deploy/**"
+          - "docker-compose.yml"
+          - ".env.production.example"
+          - ".github/workflows/**"
+          - ".github/dependabot.yml"
+
+type:testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "run_e2e.sh"
+          - "gateway/**/*_test.go"
+          - "sdk/typescript/**/__tests__/**"
+          - "web/**/*.test.*"
+          - "web/**/*.spec.*"

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -88,6 +88,11 @@ jobs:
                 color: 'FBCA04',
                 description: 'Testing-related work.',
               },
+              {
+                name: 'type:security',
+                color: 'B60205',
+                description: 'Security-sensitive report or work.',
+              },
             ];
 
             const existingLabels = new Set(
@@ -195,7 +200,10 @@ jobs:
               const title = issue.title || '';
               const body = issue.body || '';
               const text = `${title}\n${body}`.toLowerCase();
-              const labels = new Set(['triage']);
+              const labels = new Set();
+              const shouldAddTriage =
+                context.payload.action === 'opened' ||
+                context.payload.action === 'reopened';
               const componentGateway = /affected component\s*\n+\s*gateway/i.test(body);
               const componentVerifier = /affected component\s*\n+\s*verifier/i.test(body);
               const componentWeb = /affected component\s*\n+\s*web/i.test(body);
@@ -204,6 +212,14 @@ jobs:
                 /affected component\s*\n+\s*deployment/i.test(body) ||
                 /affected component\s*\n+\s*docker\/compose/i.test(body);
               const componentDocs = /affected component\s*\n+\s*documentation/i.test(body);
+              const isSecurityFallback =
+                text.includes('i need to report a security issue privately') ||
+                text.includes('need to report a security issue privately') ||
+                text.includes('report a security issue privately');
+
+              if (shouldAddTriage) {
+                labels.add('triage');
+              }
 
               const isBug =
                 text.includes('[bug]') ||
@@ -256,6 +272,9 @@ jobs:
               }
               if (componentE2E || text.includes('run_e2e.sh')) {
                 labels.add('type:testing');
+              }
+              if (isSecurityFallback) {
+                labels.add('type:security');
               }
 
               await addLabels([...labels]);

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,226 @@
+name: Issue Triage Bot
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    if: ${{ github.event.issue.pull_request == null }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Triage issue labels and claims
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue = context.payload.issue;
+
+            const triageLabel = {
+              name: 'triage',
+              color: 'd876e3',
+              description: 'Needs maintainer triage.',
+            };
+
+            const existingLabels = new Set(
+              (
+                await github.paginate(github.rest.issues.listLabelsForRepo, {
+                  owner,
+                  repo,
+                  per_page: 100,
+                })
+              ).map((label) => label.name),
+            );
+
+            async function ensureLabel(label) {
+              if (existingLabels.has(label.name)) {
+                return;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner,
+                  repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+
+              existingLabels.add(label.name);
+            }
+
+            async function addLabels(labels) {
+              const filtered = [...new Set(labels)].filter((label) =>
+                existingLabels.has(label),
+              );
+              if (filtered.length === 0) {
+                return;
+              }
+
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: issue.number,
+                labels: filtered,
+              });
+            }
+
+            async function assignUser(login) {
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: issue.number,
+                assignees: [login],
+              });
+            }
+
+            async function comment(body) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issue.number,
+                body,
+              });
+            }
+
+            function hasAssignee(login) {
+              return issue.assignees.some((assignee) => assignee.login === login);
+            }
+
+            function currentAssignees() {
+              return issue.assignees.map((assignee) => assignee.login);
+            }
+
+            await ensureLabel(triageLabel);
+
+            if (context.eventName === 'issues') {
+              const title = issue.title || '';
+              const body = issue.body || '';
+              const text = `${title}\n${body}`.toLowerCase();
+              const labels = new Set(['triage']);
+              const componentGateway = /affected component\s*\n+\s*gateway/i.test(body);
+              const componentVerifier = /affected component\s*\n+\s*verifier/i.test(body);
+              const componentWeb = /affected component\s*\n+\s*web/i.test(body);
+              const componentE2E = /affected component\s*\n+\s*e2e tests/i.test(body);
+              const componentDeployment =
+                /affected component\s*\n+\s*deployment/i.test(body) ||
+                /affected component\s*\n+\s*docker\/compose/i.test(body);
+              const componentDocs = /affected component\s*\n+\s*documentation/i.test(body);
+
+              const isBug =
+                text.includes('[bug]') ||
+                text.includes('steps to reproduce') ||
+                text.includes('expected behavior') ||
+                text.includes('actual behavior');
+              const isFeature =
+                text.includes('[feature]') ||
+                text.includes('feature request') ||
+                text.includes('problem or use case') ||
+                text.includes('proposed solution');
+
+              if (isBug) {
+                labels.add('bug');
+                labels.add('type:bug');
+              } else if (isFeature) {
+                labels.add('enhancement');
+                labels.add('type:feature');
+              }
+
+              if (
+                componentDocs ||
+                text.includes('documentation') ||
+                text.includes('readme') ||
+                text.includes('openapi') ||
+                text.includes('.env.example')
+              ) {
+                labels.add('documentation');
+                labels.add('type:docs');
+              }
+
+              if (
+                componentDeployment ||
+                text.includes('docker-compose') ||
+                text.includes('workflow') ||
+                text.includes('github action') ||
+                text.includes('github actions')
+              ) {
+                labels.add('type:devops');
+              }
+
+              if (componentGateway || text.includes('gateway/')) {
+                labels.add('go');
+              }
+              if (componentVerifier || text.includes('verifier/')) {
+                labels.add('rust');
+              }
+              if (componentWeb || text.includes('web/')) {
+                labels.add('TypeScript');
+              }
+              if (componentE2E || text.includes('run_e2e.sh')) {
+                labels.add('type:testing');
+              }
+
+              await addLabels([...labels]);
+
+              const requestedSelfAssign =
+                /please\s+assign\s+me|assign\s+me|i(?:'d|\swould)?\s+like\s+to\s+work\s+on\s+this|i\s+want\s+to\s+work\s+on\s+this/i.test(
+                  body,
+                );
+
+              if (requestedSelfAssign && issue.assignees.length === 0) {
+                await assignUser(issue.user.login);
+                await comment(
+                  `Assigned @${issue.user.login} based on the issue request.`,
+                );
+              }
+
+              return;
+            }
+
+            const issueComment = context.payload.comment;
+            if (issueComment.user.type === 'Bot') {
+              return;
+            }
+
+            const wantsClaim =
+              /^\s*\/claim\b/i.test(issueComment.body) ||
+              /^\s*\/assign\b/i.test(issueComment.body) ||
+              /\bassign me\b/i.test(issueComment.body);
+
+            if (!wantsClaim) {
+              return;
+            }
+
+            const commenter = issueComment.user.login;
+            if (hasAssignee(commenter)) {
+              return;
+            }
+
+            const assignees = currentAssignees();
+            if (assignees.length > 0) {
+              await comment(
+                `@${commenter} this issue is already assigned to ${assignees
+                  .map((login) => `@${login}`)
+                  .join(', ')}.`,
+              );
+              return;
+            }
+
+            await assignUser(commenter);
+            await comment(`Assigned @${commenter}.`);

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -27,11 +27,68 @@ jobs:
             const repo = context.repo.repo;
             const issue = context.payload.issue;
 
-            const triageLabel = {
-              name: 'triage',
-              color: 'd876e3',
-              description: 'Needs maintainer triage.',
-            };
+            const managedLabels = [
+              {
+                name: 'triage',
+                color: 'd876e3',
+                description: 'Needs maintainer triage.',
+              },
+              {
+                name: 'bug',
+                color: 'd73a4a',
+                description: 'Something is not working.',
+              },
+              {
+                name: 'type:bug',
+                color: 'd73a4a',
+                description: 'Bug report or bug fix work.',
+              },
+              {
+                name: 'enhancement',
+                color: 'a2eeef',
+                description: 'New feature or request.',
+              },
+              {
+                name: 'type:feature',
+                color: 'a2eeef',
+                description: 'Feature request or feature work.',
+              },
+              {
+                name: 'documentation',
+                color: '0075ca',
+                description: 'Documentation updates.',
+              },
+              {
+                name: 'type:docs',
+                color: '0075ca',
+                description: 'Documentation-related work.',
+              },
+              {
+                name: 'type:devops',
+                color: '5319e7',
+                description: 'CI, deployment, or automation work.',
+              },
+              {
+                name: 'go',
+                color: '00ADD8',
+                description: 'Touches Go gateway code.',
+              },
+              {
+                name: 'rust',
+                color: 'DEA584',
+                description: 'Touches Rust verifier code.',
+              },
+              {
+                name: 'TypeScript',
+                color: '3178C6',
+                description: 'Touches TypeScript or frontend code.',
+              },
+              {
+                name: 'type:testing',
+                color: 'FBCA04',
+                description: 'Testing-related work.',
+              },
+            ];
 
             const existingLabels = new Set(
               (
@@ -65,6 +122,12 @@ jobs:
               existingLabels.add(label.name);
             }
 
+            async function ensureLabels(labels) {
+              for (const label of labels) {
+                await ensureLabel(label);
+              }
+            }
+
             async function addLabels(labels) {
               const filtered = [...new Set(labels)].filter((label) =>
                 existingLabels.has(label),
@@ -82,12 +145,20 @@ jobs:
             }
 
             async function assignUser(login) {
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: issue.number,
-                assignees: [login],
-              });
+              try {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: issue.number,
+                  assignees: [login],
+                });
+                return true;
+              } catch (error) {
+                if (error.status === 403 || error.status === 422) {
+                  return false;
+                }
+                throw error;
+              }
             }
 
             async function comment(body) {
@@ -99,15 +170,26 @@ jobs:
               });
             }
 
-            function hasAssignee(login) {
-              return issue.assignees.some((assignee) => assignee.login === login);
+            async function fetchIssueState() {
+              const { data } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number: issue.number,
+              });
+              return data;
             }
 
-            function currentAssignees() {
-              return issue.assignees.map((assignee) => assignee.login);
+            function hasAssignee(issueState, login) {
+              return issueState.assignees.some(
+                (assignee) => assignee.login === login,
+              );
             }
 
-            await ensureLabel(triageLabel);
+            function currentAssignees(issueState) {
+              return issueState.assignees.map((assignee) => assignee.login);
+            }
+
+            await ensureLabels(managedLabels);
 
             if (context.eventName === 'issues') {
               const title = issue.title || '';
@@ -183,10 +265,13 @@ jobs:
                   body,
                 );
 
-              if (requestedSelfAssign && issue.assignees.length === 0) {
-                await assignUser(issue.user.login);
+              const currentIssue = await fetchIssueState();
+              if (requestedSelfAssign && currentIssue.assignees.length === 0) {
+                const assigned = await assignUser(issue.user.login);
                 await comment(
-                  `Assigned @${issue.user.login} based on the issue request.`,
+                  assigned
+                    ? `Assigned @${issue.user.login} based on the issue request.`
+                    : `GitHub did not allow assigning @${issue.user.login} automatically. A maintainer will need to assign this issue manually.`,
                 );
               }
 
@@ -208,11 +293,12 @@ jobs:
             }
 
             const commenter = issueComment.user.login;
-            if (hasAssignee(commenter)) {
+            const currentIssue = await fetchIssueState();
+            if (hasAssignee(currentIssue, commenter)) {
               return;
             }
 
-            const assignees = currentAssignees();
+            const assignees = currentAssignees(currentIssue);
             if (assignees.length > 0) {
               await comment(
                 `@${commenter} this issue is already assigned to ${assignees
@@ -222,5 +308,9 @@ jobs:
               return;
             }
 
-            await assignUser(commenter);
-            await comment(`Assigned @${commenter}.`);
+            const assigned = await assignUser(commenter);
+            await comment(
+              assigned
+                ? `Assigned @${commenter}.`
+                : `@${commenter} GitHub did not allow automatic assignment. A maintainer will need to assign this issue manually.`,
+            );

--- a/.github/workflows/pr-branch-check.yml
+++ b/.github/workflows/pr-branch-check.yml
@@ -53,12 +53,17 @@ jobs:
       - name: Add PR comment
         if: ${{ failure() }}
         uses: actions/github-script@v8
+        env:
+          BRANCH_STATUS_BEHIND: ${{ steps.check.outputs.behind }}
+          BRANCH_STATUS_AHEAD: ${{ steps.check.outputs.ahead }}
+          BRANCH_STATUS_BASE: ${{ github.event.pull_request.base.ref }}
+          BRANCH_STATUS_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         with:
           script: |
-            const behind = '${{ steps.check.outputs.behind }}';
-            const ahead = '${{ steps.check.outputs.ahead }}';
-            const base = '${{ github.event.pull_request.base.ref }}';
-            const headRef = '${{ github.event.pull_request.head.ref }}';
+            const behind = process.env.BRANCH_STATUS_BEHIND;
+            const ahead = process.env.BRANCH_STATUS_AHEAD;
+            const base = process.env.BRANCH_STATUS_BASE;
+            const headRef = process.env.BRANCH_STATUS_HEAD_REF;
             
             const body = [
               '## Branch Out of Date',

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:
@@ -16,8 +17,52 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure PR labels exist
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = [
+              { name: 'go', color: '00ADD8', description: 'Touches Go gateway code.' },
+              { name: 'rust', color: 'DEA584', description: 'Touches Rust verifier code.' },
+              { name: 'TypeScript', color: '3178C6', description: 'Touches TypeScript or frontend code.' },
+              { name: 'documentation', color: '0075CA', description: 'Documentation updates.' },
+              { name: 'github_actions', color: '5319E7', description: 'Touches GitHub Actions or repo automation.' },
+              { name: 'type:docs', color: '0075CA', description: 'Documentation-related work.' },
+              { name: 'type:devops', color: '5319E7', description: 'CI, deployment, or automation work.' },
+              { name: 'type:testing', color: 'FBCA04', description: 'Testing-related work.' },
+            ];
+
+            const existing = new Set(
+              (
+                await github.paginate(github.rest.issues.listLabelsForRepo, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  per_page: 100,
+                })
+              ).map((label) => label.name),
+            );
+
+            for (const label of labels) {
+              if (existing.has(label.name)) {
+                continue;
+              }
+
+              try {
+                await github.rest.issues.createLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: label.name,
+                  color: label.color,
+                  description: label.description,
+                });
+              } catch (error) {
+                if (error.status !== 422) {
+                  throw error;
+                }
+              }
+            }
+
       - name: Apply path-based labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@1375c42512e0b855687040307d6dcaf403da9a4e # v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,23 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply path-based labels
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -66,3 +66,4 @@ jobs:
         uses: actions/labeler@1375c42512e0b855687040307d6dcaf403da9a4e # v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+name: Stale Issues And PRs
+
+on:
+  schedule:
+    - cron: "23 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive items as stale
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 45
+          days-before-close: 7
+          stale-issue-message: >
+            This issue has been marked stale because it has had no activity for
+            45 days. If it is still relevant, add a current status update or new
+            validation details.
+          stale-pr-message: >
+            This pull request has been marked stale because it has had no
+            activity for 45 days. Rebase, respond to review, or add a status
+            update to keep it open.
+          close-issue-message: >
+            Closing as stale after 7 more days without activity. Reopen with
+            fresh context if this is still relevant.
+          close-pr-message: >
+            Closing as stale after 7 more days without activity. Reopen or open
+            a fresh PR when you are ready to continue.
+          exempt-all-assignees: true
+          exempt-issue-labels: "level:critical,type:security,good first issue,help wanted"
+          exempt-pr-labels: "type:security"
+          remove-stale-when-updated: true
+          operations-per-run: 200
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark inactive items as stale
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 45
           days-before-close: 7
@@ -38,4 +38,3 @@ jobs:
           exempt-pr-labels: "type:security"
           remove-stale-when-updated: true
           operations-per-run: 200
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,14 @@ git checkout -b docs/contributor-setup
 git checkout -b feat/web-receipt-viewer
 ```
 
+## GitHub Automation
+
+- New issues are auto-labeled for broad triage based on the issue template and body content.
+- New pull requests are auto-labeled from changed paths, for example `go`, `rust`, `TypeScript`, `documentation`, and workflow-related labels.
+- Comment `/claim` on an unassigned issue to ask the bot to assign it to you. Writing "assign me" in a new issue body also triggers self-assignment when the issue is still unassigned.
+- Inactive issues and pull requests are marked stale after 45 days and closed 7 days later unless they have an assignee or exempt labels.
+- Automation is intentionally conservative. Maintainers may adjust labels manually when the bot guesses wrong.
+
 ## Validation Matrix
 
 Run the checks for the area you touched. When a change crosses services, run every affected service's checks.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,9 @@ git checkout -b feat/web-receipt-viewer
 ## GitHub Automation
 
 - New issues are auto-labeled for broad triage based on the issue template and body content.
+- Minimal public security-fallback issues from `SECURITY.md` are auto-labeled `type:security` so stale cleanup does not close them while maintainers move the report to a private channel.
 - New pull requests are auto-labeled from changed paths, for example `go`, `rust`, `TypeScript`, `documentation`, and workflow-related labels.
+- PR path labels stay in sync with the current diff when files are added or removed from the branch.
 - Comment `/claim` on an unassigned issue to ask the bot to assign it to you. Writing "assign me" in a new issue body also triggers self-assignment when the issue is still unassigned.
 - Inactive issues and pull requests are marked stale after 45 days and closed 7 days later unless they have an assignee or exempt labels.
 - Automation is intentionally conservative. Maintainers may adjust labels manually when the bot guesses wrong.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This is a demo and contributor-friendly reference implementation. A valid signat
 | `tests/` and `run_e2e.sh` | Bun E2E flow covering unsigned challenge, signed retry, verifier acceptance, and replay rejection. |
 | `bench/` | Reproducible verifier-only micro-benchmark. It does not measure end-to-end latency. |
 | `deploy/`, `DEPLOY.md`, `.env.production.example` | Deployment prep for Render gateway/verifier, Vercel web, and Upstash Redis. Real deploy commands are manual. |
-| `.github/workflows/` | CI for Go, Rust, web, SDK, E2E, branch freshness, and Claude review integration. |
+| `.github/workflows/` | CI and repo automation for Go, Rust, web, SDK, E2E, branch freshness, PR labeling, issue triage, stale cleanup, and Claude review integration. |
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

Add conservative GitHub Actions automation for issue triage, PR labeling, and stale cleanup.

This PR adds:
- an issue triage bot that applies broad labels, creates the missing `triage` label when needed, and supports `/claim` / `assign me` for unassigned issues
- a path-based PR labeler for language and workflow labels
- a stale workflow for inactive issues and pull requests
- small contributor-doc updates describing the automation
- a security-safe fix to the existing `pr-branch-check.yml` workflow so `actionlint` passes cleanly

## Why

The repo already has issue templates and multiple CI workflows, but it does not yet have lightweight repo automation for routine issue and PR hygiene. This adds that without introducing secrets-heavy bots or broad workflow permissions.

## Validation

- `GOBIN=/tmp/codex-bin go install github.com/rhysd/actionlint/cmd/actionlint@latest && /tmp/codex-bin/actionlint .github/workflows/*.yml`
- `ruby -e 'require "yaml"; files = Dir[".github/workflows/*.yml", ".github/*.yml"]; files.each { |f| YAML.load_file(f); puts "ok #{f}" }'`
- `git diff --check`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automatic pull request labeling based on modified files.
  * Implemented automatic issue triage with component-based labeling and user self-assignment support via comments.
  * Implemented automatic stale item detection and closure workflow.

* **Documentation**
  * Updated project documentation to explain new automation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->