### PR TITLE
feat: add star-greeting bot for external PRs

### DIFF
--- a/.github/workflows/star-greeting.yml
+++ b/.github/workflows/star-greeting.yml
@@ -1,0 +1,39 @@
+name: Star Greeting Bot
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  greet:
+    if: github.event.pull_request.user.login != 'AnkanMisra'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post star greeting comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const author = context.payload.pull_request.user.login;
+            const body = [
+              `Hi @${author}, thanks for opening this PR.`,
+              '',
+              'Every contribution helps MicroAI-Paygate grow. If you find the project useful, consider starring the repository — it helps others discover it.',
+              '',
+              '[Star MicroAI-Paygate on GitHub](https://github.com/AnkanMisra/MicroAI-Paygate)',
+              '',
+              'Looking forward to reviewing this PR.'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });


### PR DESCRIPTION
Automatically posts a welcome comment on PRs opened by external contributors, thanking them and asking them to star the repository.

- Triggered on pull_request_target:opened
- Skips PRs opened by AnkanMisra
- Uses actions/github-script@v8 (consistent with existing workflows)
- Minimal permissions: pull-requests:write only

Co-Authored-By: claude[bot] <209825114+claude[bot]@users.noreply.github.com>
Co-authored-by: Devin AI <158243242+devin-ai-integration[bot]@users.noreply.github.com>
Co-authored-by: codex <codex@users.noreply.github.com>