### PR TITLE
Add early validation for receipt ID format

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -922,26 +922,59 @@ func getReceiptTTL() time.Duration {
 	}
 	return time.Duration(ttlSeconds) * time.Second
 }
+func isValidReceiptID(id string) bool {
+	if id == "" {
+		return false
+	}
+
+	if !strings.HasPrefix(id, "rcpt_") {
+		return false
+	}
+
+	// must have payload after prefix
+	if len(id) <= len("rcpt_") {
+		return false
+	}
+
+	// safety limit (prevents abuse / huge input strings)
+	if len(id) > 128 {
+		return false
+	}
+
+	return true
+}
 
 // handleGetReceipt handles GET /api/receipts/:id
 func handleGetReceipt(c *gin.Context) {
 	id := c.Param("id")
 
+	// Reject malformed IDs early (no store hit)
+	if !isValidReceiptID(id) {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error":   "invalid receipt id format",
+			"message": "receipt id must start with rcpt_ and contain an id",
+		})
+		return
+	}
+
 	receipt, exists, err := getReceiptWithContext(c.Request.Context(), id)
 	if err != nil {
 		log.Printf("Failed to retrieve receipt %s: %v", id, err)
-		c.JSON(500, gin.H{"error": "Failed to retrieve receipt"})
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "failed to retrieve receipt",
+		})
 		return
 	}
+
 	if !exists {
-		c.JSON(404, gin.H{
+		c.JSON(http.StatusNotFound, gin.H{
 			"error":   "Receipt not found",
 			"message": "Receipt may have expired or never existed",
 		})
 		return
 	}
 
-	c.JSON(200, gin.H{
+	c.JSON(http.StatusOK, gin.H{
 		"receipt":           receipt.Receipt,
 		"signature":         receipt.Signature,
 		"server_public_key": receipt.ServerPublicKey,

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -857,11 +857,8 @@ func validateReceipt(receipt *SignedReceipt) error {
 	}
 
 	// Validate receipt fields
-	if receipt.Receipt.ID == "" {
-		return fmt.Errorf("receipt ID is empty")
-	}
-	if !strings.HasPrefix(receipt.Receipt.ID, "rcpt_") {
-		return fmt.Errorf("receipt ID must start with 'rcpt_'")
+	if !isValidReceiptID(receipt.Receipt.ID) {
+		return fmt.Errorf("invalid receipt ID format")
 	}
 	if receipt.Receipt.Version == "" {
 		return fmt.Errorf("receipt version is empty")

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -62,6 +62,8 @@ type SummarizeRequest struct {
 	Text string `json:"text"`
 }
 
+var receiptIDPattern = regexp.MustCompile(`^rcpt_[a-f0-9]{12}$`)
+
 // validateConfig validates all required environment variables at startup.
 // It checks for OPENROUTER_API_KEY, SERVER_WALLET_PRIVATE_KEY, and conditionally REDIS_URL.
 // Returns an error listing all missing variables if any are not set.
@@ -924,8 +926,7 @@ func getReceiptTTL() time.Duration {
 	return time.Duration(ttlSeconds) * time.Second
 }
 func isValidReceiptID(id string) bool {
-	matched, _ := regexp.MatchString(`^rcpt_[a-f0-9]{12}$`, id)
-	return matched
+	return receiptIDPattern.MatchString(id)
 }
 
 // handleGetReceipt handles GET /api/receipts/:id
@@ -936,7 +937,7 @@ func handleGetReceipt(c *gin.Context) {
 	if !isValidReceiptID(id) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error":   "invalid receipt id format",
-			"message": "receipt id must start with rcpt_ and contain an id",
+			"message": "receipt id must start with rcpt_ followed by exactly 12 lowercase hexadecimal characters",
 		})
 		return
 	}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -19,6 +19,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -923,25 +924,8 @@ func getReceiptTTL() time.Duration {
 	return time.Duration(ttlSeconds) * time.Second
 }
 func isValidReceiptID(id string) bool {
-	if id == "" {
-		return false
-	}
-
-	if !strings.HasPrefix(id, "rcpt_") {
-		return false
-	}
-
-	// must have payload after prefix
-	if len(id) <= len("rcpt_") {
-		return false
-	}
-
-	// safety limit (prevents abuse / huge input strings)
-	if len(id) > 128 {
-		return false
-	}
-
-	return true
+	matched, _ := regexp.MatchString(`^rcpt_[a-f0-9]{12}$`, id)
+	return matched
 }
 
 // handleGetReceipt handles GET /api/receipts/:id

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -13,12 +13,15 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type spyReceiptStore struct {
 	getCalls int
+	lastID   string
+	receipt  *SignedReceipt
+	exists   bool
+	err      error
 }
 
 func (s *spyReceiptStore) Store(ctx context.Context, receipt *SignedReceipt, ttl time.Duration) error {
@@ -27,7 +30,8 @@ func (s *spyReceiptStore) Store(ctx context.Context, receipt *SignedReceipt, ttl
 
 func (s *spyReceiptStore) Get(ctx context.Context, id string) (*SignedReceipt, bool, error) {
 	s.getCalls++
-	return nil, false, nil
+	s.lastID = id
+	return s.receipt, s.exists, s.err
 }
 
 func (s *spyReceiptStore) CleanupExpired(ctx context.Context) error {
@@ -666,21 +670,86 @@ func TestIsValidReceiptID(t *testing.T) {
 	}
 }
 
-func TestHandleGetReceipt_InvalidID_DoesNotHitStore(t *testing.T) {
-	spy := &spyReceiptStore{}
+func TestHandleGetReceipt_ValidationAndLookupPaths(t *testing.T) {
+	tests := []struct {
+		name             string
+		useRouter        bool
+		id               string
+		expectedStatus   int
+		expectedBody     map[string]string
+		expectedGetCalls int
+	}{
+		{
+			name:           "empty id",
+			id:             "",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody: map[string]string{
+				"error":   "invalid receipt id format",
+				"message": "receipt id must start with rcpt_ followed by exactly 12 lowercase hexadecimal characters",
+			},
+			expectedGetCalls: 0,
+		},
+		{
+			name:           "prefix only",
+			id:             "rcpt_",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody: map[string]string{
+				"error":   "invalid receipt id format",
+				"message": "receipt id must start with rcpt_ followed by exactly 12 lowercase hexadecimal characters",
+			},
+			expectedGetCalls: 0,
+		},
+		{
+			name:           "malformed id",
+			useRouter:      true,
+			id:             "foo",
+			expectedStatus: http.StatusBadRequest,
+			expectedBody: map[string]string{
+				"error":   "invalid receipt id format",
+				"message": "receipt id must start with rcpt_ followed by exactly 12 lowercase hexadecimal characters",
+			},
+			expectedGetCalls: 0,
+		},
+		{
+			name:           "well formed but missing",
+			useRouter:      true,
+			id:             "rcpt_a1b2c3d4e5f6",
+			expectedStatus: http.StatusNotFound,
+			expectedBody: map[string]string{
+				"error":   "Receipt not found",
+				"message": "Receipt may have expired or never existed",
+			},
+			expectedGetCalls: 1,
+		},
+	}
 
-	oldStore := getActiveReceiptStore()
-	setActiveReceiptStore(spy)
-	defer setActiveReceiptStore(oldStore)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spy := &spyReceiptStore{}
 
-	router := gin.New()
-	router.GET("/api/receipts/:id", handleGetReceipt)
+			oldStore := getActiveReceiptStore()
+			setActiveReceiptStore(spy)
+			defer setActiveReceiptStore(oldStore)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/receipts/foo", nil)
-	w := httptest.NewRecorder()
+			w := httptest.NewRecorder()
 
-	router.ServeHTTP(w, req)
+			if tt.useRouter {
+				router := gin.New()
+				router.GET("/api/receipts/:id", handleGetReceipt)
+				req := httptest.NewRequest(http.MethodGet, "/api/receipts/"+tt.id, nil)
+				router.ServeHTTP(w, req)
+			} else {
+				c, _ := gin.CreateTestContext(w)
+				c.Params = gin.Params{gin.Param{Key: "id", Value: tt.id}}
+				handleGetReceipt(c)
+			}
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Equal(t, 0, spy.getCalls)
+			require.Equal(t, tt.expectedStatus, w.Code)
+			require.Equal(t, tt.expectedGetCalls, spy.getCalls)
+
+			var body map[string]string
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+			require.Equal(t, tt.expectedBody, body)
+		})
+	}
 }

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -616,27 +616,27 @@ func TestHandleReadyz_RedisUnreachable(t *testing.T) {
 	checks := response["checks"].(map[string]interface{})
 	require.Equal(t, "unreachable", checks["redis"])
 }
-
 func TestIsValidReceiptID(t *testing.T) {
 	tests := []struct {
 		name string
 		id   string
 		want bool
 	}{
+		{"valid", "rcpt_abc123def456", true},
 		{"empty", "", false},
 		{"prefix only", "rcpt_", false},
-		{"short", "rcpt_123", false},
-		{"long", "rcpt_1234567890abcdef", false},
-		{"uppercase", "rcpt_ABCDEF123456", false},
-		{"non hex", "rcpt_nothex12345", false},
+		{"short", "rcpt_abc", false},
+		{"long", "rcpt_abc123def456789", false},
+		{"uppercase", "rcpt_ABC123DEF456", false},
+		{"non hex", "rcpt_zzzzzzzzzzzz", false},
 		{"wrong prefix", "foo", false},
-		{"valid", "rcpt_abcdef123456", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isValidReceiptID(tt.id); got != tt.want {
-				t.Errorf("isValidReceiptID(%q) = %v, want %v", tt.id, got, tt.want)
+				t.Fatalf("isValidReceiptID(%q) = %v, want %v",
+					tt.id, got, tt.want)
 			}
 		})
 	}

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -616,17 +616,28 @@ func TestHandleReadyz_RedisUnreachable(t *testing.T) {
 	checks := response["checks"].(map[string]interface{})
 	require.Equal(t, "unreachable", checks["redis"])
 }
-func TestHandleGetReceipt_InvalidID(t *testing.T) {
-    w := httptest.NewRecorder()
-    c, _ := gin.CreateTestContext(w)
 
-    c.Params = gin.Params{
-        gin.Param{Key: "id", Value: "foo"},
-    }
+func TestIsValidReceiptID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"prefix only", "rcpt_", false},
+		{"short", "rcpt_123", false},
+		{"long", "rcpt_1234567890abcdef", false},
+		{"uppercase", "rcpt_ABCDEF123456", false},
+		{"non hex", "rcpt_nothex12345", false},
+		{"wrong prefix", "foo", false},
+		{"valid", "rcpt_abcdef123456", true},
+	}
 
-    handleGetReceipt(c)
-
-    if w.Code != 400 {
-        t.Fatalf("expected 400, got %d", w.Code)
-    }
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidReceiptID(tt.id); got != tt.want {
+				t.Errorf("isValidReceiptID(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
 }

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -9,10 +10,33 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type spyReceiptStore struct {
+	getCalls int
+}
+
+func (s *spyReceiptStore) Store(ctx context.Context, receipt *SignedReceipt, ttl time.Duration) error {
+	return nil
+}
+
+func (s *spyReceiptStore) Get(ctx context.Context, id string) (*SignedReceipt, bool, error) {
+	s.getCalls++
+	return nil, false, nil
+}
+
+func (s *spyReceiptStore) CleanupExpired(ctx context.Context) error {
+	return nil
+}
+
+func (s *spyReceiptStore) Close() error {
+	return nil
+}
 
 func TestHandleSummarize_NoHeaders(t *testing.T) {
 	// Setup
@@ -640,4 +664,23 @@ func TestIsValidReceiptID(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleGetReceipt_InvalidID_DoesNotHitStore(t *testing.T) {
+	spy := &spyReceiptStore{}
+
+	oldStore := getActiveReceiptStore()
+	setActiveReceiptStore(spy)
+	defer setActiveReceiptStore(oldStore)
+
+	router := gin.New()
+	router.GET("/api/receipts/:id", handleGetReceipt)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/receipts/foo", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, 0, spy.getCalls)
 }

--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -616,3 +616,17 @@ func TestHandleReadyz_RedisUnreachable(t *testing.T) {
 	checks := response["checks"].(map[string]interface{})
 	require.Equal(t, "unreachable", checks["redis"])
 }
+func TestHandleGetReceipt_InvalidID(t *testing.T) {
+    w := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(w)
+
+    c.Params = gin.Params{
+        gin.Param{Key: "id", Value: "foo"},
+    }
+
+    handleGetReceipt(c)
+
+    if w.Code != 400 {
+        t.Fatalf("expected 400, got %d", w.Code)
+    }
+}

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -252,7 +252,7 @@ paths:
                     example: invalid receipt id format
                   message:
                     type: string
-                    example: receipt id must start with rcpt_ and contain an id
+                    example: receipt id must start with rcpt_ followed by exactly 12 lowercase hexadecimal characters
         "404":
           description: Receipt expired or never existed.
           content:

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -246,6 +246,7 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [error, message]
                 properties:
                   error:
                     type: string

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -240,6 +240,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ReceiptLookupResponse"
+        "400":
+          description: Invalid receipt ID format.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid receipt id format
+                  message:
+                    type: string
+                    example: receipt id must start with rcpt_ and contain an id
         "404":
           description: Receipt expired or never existed.
           content:

--- a/gateway/openapi.yaml
+++ b/gateway/openapi.yaml
@@ -275,7 +275,7 @@ paths:
                 properties:
                   error:
                     type: string
-                    example: Failed to retrieve receipt
+                    example: failed to retrieve receipt
 
 components:
   schemas:

--- a/gateway/receipt_test.go
+++ b/gateway/receipt_test.go
@@ -243,7 +243,7 @@ func TestInMemoryReceiptStoreCopiesReceipts(t *testing.T) {
 		}
 	})
 
-	receipt := validTestReceipt("rcpt_memory_copy")
+	receipt := validTestReceipt("rcpt_abcdef123456")
 	originalSignature := receipt.Signature
 	originalNonce := receipt.Receipt.Payment.Nonce
 
@@ -255,7 +255,7 @@ func TestInMemoryReceiptStoreCopiesReceipts(t *testing.T) {
 	receipt.Signature = "0xmutated-after-store"
 	receipt.Receipt.Payment.Nonce = "mutated-after-store"
 
-	got, exists, err := store.Get(ctx, "rcpt_memory_copy")
+	got, exists, err := store.Get(ctx, "rcpt_abcdef123456")
 	if err != nil {
 		t.Fatalf("get receipt: %v", err)
 	}
@@ -272,7 +272,7 @@ func TestInMemoryReceiptStoreCopiesReceipts(t *testing.T) {
 	got.Signature = "0xmutated-after-get"
 	got.Receipt.Payment.Nonce = "mutated-after-get"
 
-	gotAgain, exists, err := store.Get(ctx, "rcpt_memory_copy")
+	gotAgain, exists, err := store.Get(ctx, "rcpt_abcdef123456")
 	if err != nil {
 		t.Fatalf("get receipt again: %v", err)
 	}

--- a/gateway/redis_receipt_store_test.go
+++ b/gateway/redis_receipt_store_test.go
@@ -24,7 +24,7 @@ func TestRedisReceiptStore_StoreGetAndTTL(t *testing.T) {
 		t.Fatalf("new redis receipt store: %v", err)
 	}
 
-	receipt := validTestReceipt("rcpt_redis123456")
+	receipt := validTestReceipt("rcpt_a1b2c3d4e5f6")
 	key := "receipt:" + receipt.Receipt.ID
 	t.Cleanup(func() {
 		_ = rdb.Del(ctx, key).Err()
@@ -122,7 +122,7 @@ func TestRedisReceiptStore_PropagatesContextErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name+"/store", func(t *testing.T) {
-			receipt := validTestReceipt("rcpt_redis_ctx_store_" + tt.name)
+			receipt := validTestReceipt("rcpt_a1b2c3d4e5f6")
 			ctx, cancel := tt.ctxFunc()
 			defer cancel()
 
@@ -141,7 +141,7 @@ func TestRedisReceiptStore_PropagatesContextErrors(t *testing.T) {
 		})
 
 		t.Run(tt.name+"/get", func(t *testing.T) {
-			receipt := validTestReceipt("rcpt_redis_ctx_get_" + tt.name)
+			receipt := validTestReceipt("rcpt_b1c2d3e4f5a6")
 			if err := store.Store(context.Background(), receipt, time.Minute); err != nil {
 				t.Fatalf("pre-store receipt: %v", err)
 			}
@@ -184,8 +184,8 @@ func TestRedisReceiptStore_RejectsNonPositiveTTL(t *testing.T) {
 		ttl  time.Duration
 		id   string
 	}{
-		{name: "zero", ttl: 0, id: "rcpt_redis_ttl_zero"},
-		{name: "negative", ttl: -1 * time.Second, id: "rcpt_redis_ttl_negative"},
+		{name: "zero", ttl: 0, id: "rcpt_d1e2f3a4b5c6"},
+		{name: "negative", ttl: -1 * time.Second, id: "rcpt_e1f2a3b4c5d6"},
 	}
 
 	for _, tt := range tests {

--- a/web/src/lib/verify-receipt.ts
+++ b/web/src/lib/verify-receipt.ts
@@ -128,7 +128,7 @@ export function validateReceiptFormat(signedReceipt: SignedReceipt): boolean {
 /**
  * Fetches a receipt by ID from the gateway
  * 
- * @param receiptId - Receipt ID (e.g., "rcpt_abc123")
+ * @param receiptId - Receipt ID (e.g., "rcpt_a1b2c3d4e5f6")
  * @param gatewayUrl - Gateway base URL (default: http://localhost:3000)
  * @returns Promise<SignedReceipt | null>
  */


### PR DESCRIPTION

Closes #210

## Summary
Adds early validation for receipt IDs in handleGetReceipt to reject malformed IDs before hitting the store layer.

## Changes
- Added isValidReceiptID helper to validate rcpt_ prefix and basic format
- Updated handleGetReceipt to return 400 for malformed IDs
- Ensures store is not queried for invalid requests

## Behavior
- Malformed IDs → 400 Bad Request
- Well-formed but missing IDs → 404 Not Found
- Valid IDs → normal lookup flow

## Testing
- Added/updated table-driven tests covering valid, malformed, and empty IDs
- Verified with go test ./...

## Non-breaking
No changes to receipt generation or x402 verification logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Receipt retrieval now validates receipt IDs against the documented `rcpt_` + 12 lowercase-hex format before any lookup, returning **HTTP 400** with `error` and `message` for invalid inputs.  
  * **HTTP 500** response payload was simplified while keeping **404** and success behavior unchanged.
* **Tests**
  * Added/extended coverage for valid/invalid receipt ID formats and verified invalid requests don’t query the receipt store.
  * Updated receipt ID fixtures used by in-memory and Redis store tests.
* **Documentation**
  * Updated the OpenAPI spec for the **400** response body and adjusted the **500** example message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->