### PR TITLE
test: add receipt storage unit tests

### DIFF
--- a/web/src/lib/receipt-storage.test.ts
+++ b/web/src/lib/receipt-storage.test.ts
@@ -184,6 +184,8 @@ it("notifies subscribers after successful mutations", () => {
 
   unsubscribe();
 
+  saveReceipt(mockReceipt, "test");
+
   expect(calls).toBe(3);
 });
 

--- a/web/src/lib/receipt-storage.test.ts
+++ b/web/src/lib/receipt-storage.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 
 import {
   clearReceipts,
@@ -37,19 +37,39 @@ const mockReceipt: SignedReceipt = {
 
 const storage = new Map<string, string>();
 
+type TestGlobals = {
+  localStorage?: {
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+    removeItem: (key: string) => void;
+    clear: () => void;
+  };
+  window?: {
+    localStorage?: unknown;
+  };
+};
+
+const testGlobals = globalThis as unknown as TestGlobals;
+
 beforeEach(() => {
   storage.clear();
 
-  (globalThis as any).localStorage = {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, value: string) => storage.set(key, value),
-    removeItem: (key: string) => storage.delete(key),
-    clear: () => storage.clear(),
-  };
+  testGlobals.localStorage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+  clear: () => {
+    storage.clear();
+  },
+};
 
-  (globalThis as any).window = {
-    localStorage: (globalThis as any).localStorage,
-  };
+testGlobals.window = {
+  localStorage: testGlobals.localStorage,
+};
 });
 
 describe("receipt-storage", () => {
@@ -133,12 +153,12 @@ it("caps stored history at 20 entries with newest first", () => {
 });
 
 it("saveReceipt does not throw when localStorage fails", () => {
-  (globalThis as any).localStorage.setItem = () => {
+  testGlobals.localStorage!.setItem = () => {
     throw new Error("storage failed");
   };
 
-  (globalThis as any).window.localStorage =
-    (globalThis as any).localStorage;
+  testGlobals.window!.localStorage =
+    testGlobals.localStorage;
 
   expect(() => {
     saveReceipt(mockReceipt, "test");
@@ -146,12 +166,12 @@ it("saveReceipt does not throw when localStorage fails", () => {
 });
 
 it("removeReceipt does not throw when localStorage fails", () => {
-  (globalThis as any).localStorage.setItem = () => {
+  testGlobals.localStorage!.setItem = () => {
     throw new Error("storage failed");
   };
 
-  (globalThis as any).window.localStorage =
-    (globalThis as any).localStorage;
+  testGlobals.window!.localStorage =
+    testGlobals.localStorage;
 
   expect(() => {
     removeReceipt("rcpt_123");
@@ -159,12 +179,12 @@ it("removeReceipt does not throw when localStorage fails", () => {
 });
 
 it("clearReceipts does not throw when localStorage fails", () => {
-  (globalThis as any).localStorage.removeItem = () => {
+  testGlobals.localStorage!.removeItem = () => {
     throw new Error("storage failed");
   };
 
-  (globalThis as any).window.localStorage =
-    (globalThis as any).localStorage;
+  testGlobals.window!.localStorage =
+    testGlobals.localStorage;
 
   expect(() => {
     clearReceipts();

--- a/web/src/lib/receipt-storage.test.ts
+++ b/web/src/lib/receipt-storage.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import {
+  clearReceipts,
+  listReceipts,
+  removeReceipt,
+  saveReceipt,
+  subscribeReceipts,
+} from "./receipt-storage";
+
+import type { SignedReceipt } from "./verify-receipt";
+
+const mockReceipt: SignedReceipt = {
+  receipt: {
+    id: "rcpt_123",
+    version: "1.0",
+    timestamp: "2026-06-19T00:00:00Z",
+    payment: {
+      payer: "0x1111111111111111111111111111111111111111",
+      recipient: "0x2222222222222222222222222222222222222222",
+      amount: "100",
+      token: "USDC",
+      chainId: 84532,
+      nonce: "nonce-1",
+    },
+    service: {
+      endpoint: "/api/test",
+      request_hash: "req-hash",
+      response_hash: "res-hash",
+    },
+  },
+  signature:
+    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  server_public_key:
+    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+};
+
+const storage = new Map<string, string>();
+
+beforeEach(() => {
+  storage.clear();
+
+  (globalThis as any).localStorage = {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+    clear: () => storage.clear(),
+  };
+
+  (globalThis as any).window = {
+    localStorage: (globalThis as any).localStorage,
+  };
+});
+
+describe("receipt-storage", () => {
+  it("ignores malformed JSON instead of crashing", () => {
+    localStorage.setItem("microai:receipts", "{bad json");
+
+    expect(() => listReceipts()).not.toThrow();
+    expect(listReceipts()).toEqual([]);
+  });
+
+  it("ignores stale schema entries", () => {
+    localStorage.setItem(
+      "microai:receipts",
+      JSON.stringify([
+        {
+          savedAt: Date.now(),
+          receipt: {
+            bad: "data",
+          },
+        },
+      ])
+    );
+
+    expect(listReceipts()).toEqual([]);
+  });
+
+  it("deduplicates receipts by receipt id", () => {
+  saveReceipt(mockReceipt, "first");
+
+  saveReceipt(
+    {
+      ...mockReceipt,
+      receipt: {
+        ...mockReceipt.receipt,
+        payment: {
+          ...mockReceipt.receipt.payment,
+          amount: "999",
+        },
+      },
+    },
+    "second"
+  );
+
+  const receipts = listReceipts();
+
+  expect(receipts).toHaveLength(1);
+  expect(receipts[0]?.promptPreview).toBe("second");
+  expect(receipts[0]?.receipt.receipt.payment.amount).toBe("999");
+});
+
+it("trims promptPreview to 80 characters", () => {
+  const longPrompt = "a".repeat(120);
+
+  saveReceipt(mockReceipt, longPrompt);
+
+  const receipts = listReceipts();
+
+  expect(receipts[0]?.promptPreview.length).toBe(80);
+  expect(receipts[0]?.promptPreview).toBe("a".repeat(80));
+});
+
+it("caps stored history at 20 entries with newest first", () => {
+  for (let i = 0; i < 25; i++) {
+    saveReceipt(
+      {
+        ...mockReceipt,
+        receipt: {
+          ...mockReceipt.receipt,
+          id: `receipt-${i}`,
+        },
+      },
+      `prompt-${i}`
+    );
+  }
+
+  const receipts = listReceipts();
+
+  expect(receipts).toHaveLength(20);
+  expect(receipts[0]?.receipt.receipt.id).toBe("receipt-24");
+  expect(receipts[19]?.receipt.receipt.id).toBe("receipt-5");
+});
+
+it("saveReceipt does not throw when localStorage fails", () => {
+  (globalThis as any).localStorage.setItem = () => {
+    throw new Error("storage failed");
+  };
+
+  (globalThis as any).window.localStorage =
+    (globalThis as any).localStorage;
+
+  expect(() => {
+    saveReceipt(mockReceipt, "test");
+  }).not.toThrow();
+});
+
+it("removeReceipt does not throw when localStorage fails", () => {
+  (globalThis as any).localStorage.setItem = () => {
+    throw new Error("storage failed");
+  };
+
+  (globalThis as any).window.localStorage =
+    (globalThis as any).localStorage;
+
+  expect(() => {
+    removeReceipt("rcpt_123");
+  }).not.toThrow();
+});
+
+it("clearReceipts does not throw when localStorage fails", () => {
+  (globalThis as any).localStorage.removeItem = () => {
+    throw new Error("storage failed");
+  };
+
+  (globalThis as any).window.localStorage =
+    (globalThis as any).localStorage;
+
+  expect(() => {
+    clearReceipts();
+  }).not.toThrow();
+});
+
+it("notifies subscribers after successful mutations", () => {
+  let calls = 0;
+
+  const unsubscribe = subscribeReceipts(() => {
+    calls++;
+  });
+
+  saveReceipt(mockReceipt, "test");
+  removeReceipt(mockReceipt.receipt.id);
+  clearReceipts();
+
+  unsubscribe();
+
+  expect(calls).toBe(3);
+});
+
+});


### PR DESCRIPTION
## Description

Added dedicated unit tests for receipt-storage.ts covering receipt persistence, schema validation, deduplication, history limits, localStorage failure handling, and subscriber notifications.

## Related Issue

Closes #234

## Type of Change

- [x] Tests

## Changes Made

- Added a new test file: web/src/lib/receipt-storage.test.ts
- Verified malformed JSON entries are ignored without crashing
- Verified stale-schema entries are filtered out safely
- Verified saveReceipt deduplicates receipts by receipt.receipt.id
- Verified promptPreview is trimmed to 80 characters
- Verified stored receipt history is capped at 20 entries with newest entries first
- Verified saveReceipt, removeReceipt, and clearReceipts do not throw when localStorage operations fail
- Verified subscribers are notified after successful mutations

## Testing

Ran:

bun test src/lib/receipt-storage.test.ts
bun test

Result:
67 pass
0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Bun test suite covering receipt storage behaviors, including resilience to malformed or invalid data, deduplication by receipt ID, trimming of `promptPreview`, and limiting stored history to the most recent 20 entries.
  * Verified mutation APIs (`save`, `remove`, `clear`) safely handle storage errors without throwing.
  * Added tests for receipt subscription notifications, including proper unsubscribe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->