### PR TITLE
fix: repair post-merge automation failures

### DIFF
--- a/.github/scripts/issue-triage.js
+++ b/.github/scripts/issue-triage.js
@@ -14,6 +14,13 @@ const CLAIMABLE_LABELS = new Set([
   "gssoc:approved",
 ]);
 
+const TYPE_LABELS = new Set([
+  "bug",
+  "type:bug",
+  "enhancement",
+  "type:feature",
+]);
+
 const COMPONENT_LABELS = new Map([
   ["gateway", ["go"]],
   ["verifier", ["rust"]],
@@ -73,12 +80,22 @@ function staleInferredLabels(issue, changes, currentLabels) {
     labels: [],
   };
   const previous = inferStructuredLabels(previousIssue);
-  if (!previous.isStructured) return [];
-
   const next = inferStructuredLabels({ ...issue, labels: [] });
-  return [...previous.labels].filter(
-    (label) => currentLabels.has(label) && !next.labels.has(label),
-  );
+  const stale = new Set();
+
+  if (previous.isStructured) {
+    for (const label of previous.labels) {
+      if (currentLabels.has(label) && !next.labels.has(label)) stale.add(label);
+    }
+  }
+
+  if (next.isStructured) {
+    for (const label of TYPE_LABELS) {
+      if (currentLabels.has(label) && !next.labels.has(label)) stale.add(label);
+    }
+  }
+
+  return [...stale];
 }
 
 function shouldAddTriage(action, issue) {

--- a/.github/scripts/issue-triage.js
+++ b/.github/scripts/issue-triage.js
@@ -89,7 +89,10 @@ function staleInferredLabels(issue, changes, currentLabels) {
     }
   }
 
-  if (next.isStructured) {
+  const nextHasInferredType = [...TYPE_LABELS].some((label) =>
+    next.labels.has(label),
+  );
+  if (next.isStructured && nextHasInferredType) {
     for (const label of TYPE_LABELS) {
       if (currentLabels.has(label) && !next.labels.has(label)) stale.add(label);
     }

--- a/.github/scripts/issue-triage.test.js
+++ b/.github/scripts/issue-triage.test.js
@@ -100,6 +100,19 @@ test("structured titles replace conflicting type labels without edit history", (
   assert.deepEqual(stale.sort(), ["bug", "type:bug"]);
 });
 
+test("body-only structured edits preserve maintainer type labels", () => {
+  const currentIssue = issue({
+    title: "Gateway request fails in one environment",
+    body: "### Affected component\n\nGateway",
+  });
+  const stale = staleInferredLabels(
+    currentIssue,
+    { body: { from: "Free-form issue body" } },
+    new Set(["bug"]),
+  );
+  assert.deepEqual(stale, []);
+});
+
 test("triage is skipped for ready or terminal issues", () => {
   assert.equal(shouldAddTriage("opened", issue()), true);
   for (const name of [

--- a/.github/scripts/issue-triage.test.js
+++ b/.github/scripts/issue-triage.test.js
@@ -87,6 +87,19 @@ test("structured type edits replace stale category labels", () => {
   assert.deepEqual(stale.sort(), ["bug", "type:bug"]);
 });
 
+test("structured titles replace conflicting type labels without edit history", () => {
+  const currentIssue = issue({
+    title: "[Feature]: Add a gateway option",
+    body: "### Affected component\n\nGateway",
+  });
+  const stale = staleInferredLabels(
+    currentIssue,
+    undefined,
+    new Set(["bug", "type:bug", "go"]),
+  );
+  assert.deepEqual(stale.sort(), ["bug", "type:bug"]);
+});
+
 test("triage is skipped for ready or terminal issues", () => {
   assert.equal(shouldAddTriage("opened", issue()), true);
   for (const name of [

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- reconcile conflicting issue type labels from the current structured title even when edit-history data is unavailable
- retain previous-form comparison for stale component labels and preserve maintainer labels on free-form issues
- pin OpenSSF Scorecard v2.4.3 to the dereferenced action commit accepted by Scorecard publishing

## Root cause

The post-merge smoke test on issue #270 showed that changing a structured issue from Bug to Feature added the new labels without removing the old labels. Cleanup depended on the webhook's previous-title data, which was not sufficient in the live run. Structured type labels are mutually exclusive, so the current title now acts as their source of truth.

The first Scorecard run completed its scan but publishing rejected the annotated tag object SHA as an imposter commit. The workflow now uses the tag's dereferenced commit SHA.

## Impact

Edited issue forms no longer accumulate contradictory bug and feature labels, and Scorecard can publish results from the default branch.

## Validation

- `node --test .github/scripts/*.test.js` (10 passed)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- parsed `.github/workflows/scorecards.yml` as YAML
- verified `refs/tags/v2.4.3^{}` resolves to `4eaacf0543bb3f2c246792bd56e8cdeffafb205a`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates post-merge issue triage and Scorecard publishing.

- Reconciles conflicting type labels from the current issue form.
- Adds coverage for missing edit-history data.
- Pins Scorecard to the dereferenced v2.4.3 action commit.

<h3>Confidence Score: 4/5</h3>

The changed label-reconciliation path can delete a maintainer-applied type label during a body-only issue edit.

- Adding an affected-component section can make the cleanup treat a manually applied `bug` label as stale.
- The Scorecard commit pin matches the intended action release.

.github/scripts/issue-triage.js

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/issue-triage.js | Adds current-form type-label cleanup but can remove a maintainer-applied type label when an issue first gains a component section. |
| .github/scripts/issue-triage.test.js | Covers cleanup without edit history but not preservation of manually applied type labels during a free-form-to-component transition. |
| .github/workflows/scorecards.yml | Pins Scorecard to the dereferenced v2.4.3 commit used by result publishing. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ankanmisra%2Fmicroai-paygate%22%20on%20the%20existing%20branch%20%22fix%2Fpost-merge-automation-smoke%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fpost-merge-automation-smoke%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fscripts%2Fissue-triage.js%3A92-96%0A**Maintainer%20type%20labels%20are%20removed**%0A%0AWhen%20a%20free-form%20issue%20with%20a%20manually%20applied%20%60bug%60%20label%20is%20edited%20to%20add%20an%20%60Affected%20component%60%20section%20but%20keeps%20an%20ordinary%20title%2C%20%60next.isStructured%60%20becomes%20true%20while%20%60next.labels%60%20contains%20no%20type%20label.%20This%20loop%20removes%20%60bug%60%20as%20stale%20even%20though%20the%20title%20did%20not%20infer%20it%2C%20so%20the%20body-only%20edit%20deletes%20a%20maintainer-managed%20label.%0A%0A&repo=ankanmisra%2Fmicroai-paygate&pr=278&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/scripts/issue-triage.js:92-96
**Maintainer type labels are removed**

When a free-form issue with a manually applied `bug` label is edited to add an `Affected component` section but keeps an ordinary title, `next.isStructured` becomes true while `next.labels` contains no type label. This loop removes `bug` as stale even though the title did not infer it, so the body-only edit deletes a maintainer-managed label.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: repair post-merge automation failur..."](https://github.com/ankanmisra/microai-paygate/commit/7d36c0117d958424bf0253ae467978d4f48b88e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43516644)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved issue triage so outdated inferred labels are removed when issue titles change.
  - Correctly detects conflicting type labels in structured issue titles.
  - Preserves maintainer-applied type labels when only an issue body is edited.

- **Chores**
  - Updated the security scorecard workflow to use a newer verified action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->