### PR TITLE
fix: use dereferenced CodeQL action pin

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -47,6 +47,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@1ad29ea4a422cce9a242a9fae469541dcd08addc # v4
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

- pin `github/codeql-action/upload-sarif` to the dereferenced `v4` commit
- allow OpenSSF Scorecard workflow verification and result publishing to complete

## Root cause

The Scorecard action now runs from its correct dereferenced commit, but its workflow verifier rejects the annotated `github/codeql-action` tag object (`1ad29e...`) as an imposter commit. The workflow must reference the commit the `v4` tag resolves to (`99df26d...`).

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- parsed `.github/workflows/scorecards.yml` as YAML
- verified `refs/tags/v4^{}` resolves to `99df26d4f13ea111d4ec1a7dddef6063f76b97e9`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the CodeQL SARIF upload action pin in the Scorecard workflow.

- Replaces the annotated tag-object SHA with the dereferenced v4 commit.
- Keeps the existing SARIF file input and workflow permissions unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/scorecards.yml | Updates the upload-sarif action pin while preserving the Scorecard result upload flow. |

<sub>Reviews (1): Last reviewed commit: ["fix: use dereferenced CodeQL action pin"](https://github.com/ankanmisra/microai-paygate/commit/2a2c4de40f5d9caa109dca0ceb210285c3833636) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43532330)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->