### PR TITLE
docs: add Bun installation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is a demo and contributor-friendly reference implementation. A valid signat
 | Goal | Read |
 | --- | --- |
 | Run locally | [Getting Started](#getting-started-local) |
-| Build an API client | [Use the SDK](#use-the-sdk) |
+| Build an API client | [Use The SDK](#use-the-sdk) |
 | Read website docs | Run `cd web && bun run dev`, then open `/docs` |
 | Understand the architecture | [Architecture](#architecture) |
 | Contribute code or docs | [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -220,6 +220,8 @@ flowchart LR
 
 ### Install
 
+> **Note:** Ensure Bun is installed before running the installation commands, as it is required for dependency installation and project scripts.
+
 ```bash
 git clone https://github.com/AnkanMisra/MicroAI-Paygate.git
 cd MicroAI-Paygate
@@ -229,8 +231,6 @@ bun install
 (cd gateway && go mod download)
 (cd verifier && cargo build -q)
 ```
-
-> **Note:** Ensure Bun is installed before running the installation commands, as it is required for dependency installation and project scripts.
 
 ### Configure
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This is a demo and contributor-friendly reference implementation. A valid signat
 | Goal | Read |
 | --- | --- |
 | Run locally | [Getting Started](#getting-started-local) |
-| Build an API client | [Use The SDK](#use-the-sdk) |
+| Build an API client | [Use the SDK](#use-the-sdk) |
 | Read website docs | Run `cd web && bun run dev`, then open `/docs` |
 | Understand the architecture | [Architecture](#architecture) |
 | Contribute code or docs | [CONTRIBUTING.md](CONTRIBUTING.md) |
@@ -229,6 +229,8 @@ bun install
 (cd gateway && go mod download)
 (cd verifier && cargo build -q)
 ```
+
+> **Note:** Ensure Bun is installed before running the installation commands, as it is required for dependency installation and project scripts.
 
 ### Configure
 


### PR DESCRIPTION
## Summary

- Added a note to the installation section clarifying that Bun must be installed before running the setup commands, helping users avoid setup issues during project initialization.

## Type Of Change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Tests
- [ ] Refactor
- [ ] Deployment/config

## Affected Areas

- [ ] Gateway (`gateway/`)
- [ ] Verifier (`verifier/`)
- [ ] Web (`web/`)
- [ ] E2E/tests (`tests/`, `run_e2e.sh`)
- [ ] Benchmarks (`bench/`)
- [ ] Deployment/config (`deploy/`, Docker, env, workflows)
- [x] Documentation/community files

## Contributor Checklist

- [x] I kept the change focused and avoided unrelated refactors.
- [x] I updated README/service docs/OpenAPI/env examples when behavior, config, headers, status codes, or public APIs changed.
- [x] I did not commit secrets, private keys, funded wallets, API keys, or real production URLs.
- [ ] I checked x402/EIP-712 field parity when touching payment context, signatures, timestamps, nonces, chain IDs, receipts, or wallet flow.
- [ ] I checked Docker/Compose/Fly/Vercel docs when touching ports, service names, health checks, or environment variables.

## Verification

List the exact commands you ran and their result.

```text
Reviewed the updated README locally to ensure the added note is placed in the appropriate section and does not affect the existing installation workflow.
```

## Screenshots

N/A (Documentation-only change)

## Notes For Reviewers

This is a small documentation improvement intended to make the installation process clearer for new contributors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SDK link text capitalization in the “Start Here” table.
  * Added a bold note to the “Install” instructions reminding readers to ensure Bun is installed before running installation commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->