### PR TITLE
docs: rebuild project documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ flowchart LR
 | Component | Path | Main responsibility |
 | --- | --- | --- |
 | Gateway | `gateway/` | Go/Gin HTTP gateway, x402 challenge creation, verifier orchestration, AI provider calls, CORS, gzip, rate limits, Redis cache, receipts, health/readiness. |
-| Verifier | `verifier/` | Rust/Axum EIP-712 signature verification, expected chain enforcement, timestamp freshness, in-memory nonce replay protection. |
+| Verifier | `verifier/` | Rust/Axum EIP-712 signature verification, expected chain enforcement, timestamp freshness, and memory- or Redis-backed nonce replay protection. |
 | Web | `web/` | Next.js frontend, wallet detection, configured-chain switching, EIP-712 signing, signed retry, result display. |
 | SDK | `sdk/typescript/` | Private TypeScript SDK for the current x402-style protocol, including challenge handling, EIP-712 signing, signed retry headers, receipt decoding, and trusted-key receipt verification. |
 | E2E | `tests/`, `run_e2e.sh` | Bun tests for unsigned challenge, signed retry, upstream behavior, and replay rejection. |
@@ -39,7 +39,7 @@ Install:
 - Bun `1.3.13+`
 - Go `1.24.x`
 - Rust stable
-- Docker and Redis only when using Docker Compose or Redis-backed local receipts/cache
+- Docker and Redis only when using Compose or Redis-backed nonce, receipt, or cache modes
 
 Then run:
 
@@ -60,6 +60,9 @@ Edit `.env` with development values. Use an unfunded local server wallet key. Ne
 Start the local stack:
 
 ```bash
+RECEIPT_STORE=memory \
+VERIFIER_NONCE_STORE=memory \
+CACHE_ENABLED=false \
 bun run stack
 ```
 
@@ -69,7 +72,7 @@ This starts:
 - Web: `http://localhost:3001`
 - Verifier: `http://localhost:3002`
 
-The root stack command defaults to memory receipts and cache disabled unless those values are exported in your shell, so Redis is not required for the normal quick start.
+The copied `.env` selects Redis-backed stores. The command above explicitly overrides both stores for a no-Redis quick start; shell values take precedence over Bun's automatic `.env` loading.
 
 ## Docker Compose Setup
 
@@ -124,7 +127,7 @@ Run the checks for the area you touched. When a change crosses services, run eve
 | `verifier/**` | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test` |
 | `web/**` | `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` |
 | `sdk/typescript/**` | `cd sdk/typescript && bun run typecheck && bun run test` |
-| `tests/**` or x402 flow | `bun run test:e2e` when `OPENROUTER_API_KEY` is available |
+| `tests/**` or x402 flow | `RECEIPT_STORE=memory VERIFIER_NONCE_STORE=memory CACHE_ENABLED=false bun run test:e2e` when `OPENROUTER_API_KEY` is available |
 | `gateway/openapi.yaml` | YAML parse plus compare against gateway routes |
 | `.github/workflows/**` | YAML parse and explain which paths trigger checks |
 | Docker/Compose/deploy docs | Validate YAML/TOML where practical and do not run real deploy commands unless maintainers explicitly approve |
@@ -188,10 +191,12 @@ If you change a public gateway endpoint, update `gateway/openapi.yaml` in the sa
 
 ## E2E Behavior
 
-`bun run test:e2e` uses `run_e2e.sh` to build and start the verifier and gateway before running Bun tests. The helper defaults to:
+`bun run test:e2e` uses `run_e2e.sh` to build and start the verifier and gateway before running Bun tests. When the variables are unset, the helper defaults the gateway to:
 
 - `RECEIPT_STORE=memory`
 - `CACHE_ENABLED=false`
+
+If you copied `.env.example`, explicitly override `RECEIPT_STORE` and `VERIFIER_NONCE_STORE` to `memory` when testing without Redis.
 
 The default OpenRouter path still requires `OPENROUTER_API_KEY` for gateway startup. If a signed request returns `502 upstream_unavailable` or `504 upstream_timeout`, payment verification may have succeeded and only the upstream model call failed. Read the test output before assuming the x402 flow broke.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ docker compose up --build
 | `GET /api/receipts/{id}` | Fetch a stored signed receipt before its TTL expires. |
 | `GET /healthz` | Gateway liveness. |
 | `GET /readyz` | Verifier, provider, Redis-when-required, and gateway readiness. |
-| `GET /metrics` | Prometheus metrics; configurable with `METRICS_PATH`. |
+| `GET /metrics` | Prometheus metrics when `METRICS_ENABLED` is enabled; configurable with `METRICS_PATH`. |
 | `GET /openapi.yaml` | Raw OpenAPI contract. |
 | `GET /docs` | Swagger UI. |
 
@@ -192,6 +192,13 @@ cd sdk/typescript
 bun install
 bun run typecheck
 bun run test
+```
+
+Install the unpublished package in another local app before importing it:
+
+```bash
+cd /path/to/your-app
+bun add /path/to/MicroAI-Paygate/sdk/typescript
 ```
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -1,226 +1,117 @@
 <div align="center">
   <h1>MicroAI Paygate</h1>
-  <img src="public/rootimage.png" alt="MicroAI Paygate Architecture" style="max-width:640px; width:100%; height:auto;" />
-  <p>Open source x402-style payment gateway for AI API requests.</p>
+
+  <img src="public/rootimage.png" alt="MicroAI Paygate" width="900" />
+
+  <p><strong>Payment authorization, replay protection, and signed receipts for AI APIs.</strong></p>
+
+  <p>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/go-tests.yml"><img alt="Go Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/go-tests.yml/badge.svg" /></a>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/rust-tests.yml"><img alt="Rust Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/rust-tests.yml/badge.svg" /></a>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/web-lint-build.yml"><img alt="Web Build" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/web-lint-build.yml/badge.svg" /></a>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/sdk-tests.yml"><img alt="SDK Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/sdk-tests.yml/badge.svg" /></a>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/e2e.yml"><img alt="E2E Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/e2e.yml/badge.svg" /></a>
+    <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/codeql-analysis.yml"><img alt="CodeQL" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/codeql-analysis.yml/badge.svg" /></a>
+  </p>
+
+  <p>
+    <a href="#overview">Overview</a> ·
+    <a href="#how-it-works">How it works</a> ·
+    <a href="#quick-start">Quick start</a> ·
+    <a href="#api-and-sdk">API and SDK</a> ·
+    <a href="#development">Development</a> ·
+    <a href="https://microai-paygate.vercel.app">Live demo</a>
+  </p>
 </div>
 
-<p align="center">
-  <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/go-tests.yml"><img alt="Go Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/go-tests.yml/badge.svg"></a>
-  <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/rust-tests.yml"><img alt="Rust Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/rust-tests.yml/badge.svg"></a>
-  <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/web-lint-build.yml"><img alt="Web Build" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/web-lint-build.yml/badge.svg"></a>
-  <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/sdk-tests.yml"><img alt="SDK Tests" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/sdk-tests.yml/badge.svg"></a>
-  <a href="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/e2e.yml"><img alt="E2E" src="https://github.com/AnkanMisra/MicroAI-Paygate/actions/workflows/e2e.yml/badge.svg"></a>
-  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
-</p>
+## Overview
 
-## Live Demo
+MicroAI Paygate is an open-source reference stack for payment-gated AI requests. It combines a Go API gateway, a Rust EIP-712 verifier, a Next.js wallet experience, configurable memory or Redis state, and a local TypeScript SDK.
 
-**https://microai-paygate.vercel.app**
+An unsigned request receives HTTP `402 Payment Required`. The client signs the returned payment context, retries with `X-402-*` headers, and receives an AI result plus a gateway-signed receipt.
 
-The backend services (gateway + verifier) are hosted on Render's free tier and **sleep after 15 minutes of inactivity**. The first request after a quiet period takes 30–50 seconds while both services wake. The web UI shows a brief warm-up banner during this window. Subsequent requests are normal speed.
+> [!IMPORTANT]
+> This project is **x402-style**, not an official x402 implementation. A valid signature proves wallet authorization for a payment context; it does not prove that USDC moved on-chain or that facilitator settlement occurred.
 
-The deployed stack is **Render** (Rust verifier + Go gateway) + **Vercel** (Next.js web) + **Upstash** (Redis for nonces and signed receipts). All on free tiers — total recurring cost is $0. See [DEPLOY.md](DEPLOY.md) for the step-by-step deployment guide.
+### Live demo
 
-The demo runs on **Base Sepolia testnet**. A valid EIP-712 signature proves wallet authorization for the payment context; it does not move USDC on-chain. Bring a wallet on Base Sepolia to try the full sign-and-summarize flow.
+Try the Base Sepolia demo at **[microai-paygate.vercel.app](https://microai-paygate.vercel.app)**.
 
-## What This Project Does
+> [!NOTE]
+> The gateway and verifier run on Render's free tier and can sleep after inactivity. The first request may take 30–50 seconds while both services wake.
 
-MicroAI Paygate demonstrates a payment-gated AI microservice stack. A client asks the gateway for an AI summary. If the request is unsigned, the gateway returns HTTP `402 Payment Required` with a payment context. The client signs that context with an EVM wallet using EIP-712 typed data and retries the request with `X-402-*` headers. The gateway verifies the signature through a Rust verifier service, calls the configured AI provider, signs a receipt, stores it, and returns the AI result.
+### Highlights
 
-This is a demo and contributor-friendly reference implementation. A valid signature proves wallet authorization for the payment context; it does not prove that USDC moved on-chain.
+- **Explicit authorization** — wallets sign EIP-712 payment contexts before the AI provider is called.
+- **Replay protection** — the verifier supports process-local memory or shared Redis nonce claims.
+- **Signed receipts** — the gateway signs request and response hashes and supports receipt lookup by ID.
+- **Operational controls** — timeouts, CORS, rate limits, optional response caching, health checks, and Prometheus metrics are built in.
+- **Two client paths** — use the browser wallet flow or the repo-local TypeScript SDK.
+- **Two AI providers** — OpenRouter is the default; Ollama is available for local experiments.
 
-## Start Here
-
-| Goal | Read |
-| --- | --- |
-| Run locally | [Getting Started](#getting-started-local) |
-| Build an API client | [Use The SDK](#use-the-sdk) |
-| Read website docs | Run `cd web && bun run dev`, then open `/docs` |
-| Understand the architecture | [Architecture](#architecture) |
-| Contribute code or docs | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Review project rules | [RULES.md](RULES.md) |
-| Report vulnerabilities | [SECURITY.md](SECURITY.md) |
-| Get support | [SUPPORT.md](SUPPORT.md) |
-| Deploy manually | [DEPLOY.md](DEPLOY.md) |
-| Gateway API contract | [gateway/openapi.yaml](gateway/openapi.yaml) or `GET /docs` from the gateway |
-
-## Repository Map
-
-| Path | Purpose |
-| --- | --- |
-| `gateway/` | Go/Gin API gateway on port `3000`. Owns CORS, gzip, rate limits, timeouts, Redis cache, receipt storage, AI provider calls, x402 challenge creation, verifier calls, and receipt signing. |
-| `verifier/` | Rust/Axum service on port `3002`. Verifies EIP-712 payment signatures, chain ID, timestamp freshness, and nonce replay for a single verifier instance. |
-| `web/` | Next.js/Bun frontend on port `3001`. Requests summaries, handles `402` payment contexts, switches wallet chain, signs typed data, and retries with `X-402-*` headers. |
-| `sdk/typescript/` | Private/local TypeScript SDK package for AI API builders. Handles `402` challenges, EIP-712 signing, signed retries, receipt decoding, and trusted-key receipt verification. |
-| `tests/` and `run_e2e.sh` | Bun E2E flow covering unsigned challenge, signed retry, verifier acceptance, and replay rejection. |
-| `bench/` | Reproducible verifier-only micro-benchmark. It does not measure end-to-end latency. |
-| `deploy/`, `DEPLOY.md`, `.env.production.example` | Deployment prep for Render gateway/verifier, Vercel web, and Upstash Redis. Real deploy commands are manual. |
-| `.github/workflows/` | CI and repository automation for Go, Rust, web, SDK, E2E, branch freshness, PR labeling, issue triage, stale cleanup, CodeQL security analysis, and Claude review integration. |
-
-## Architecture
-
-```mermaid
-flowchart TB
-    Client["Browser, CLI, or agent client"]
-    Web["web/ Next.js app :3001"]
-    Gateway["gateway/ Go Gin API :3000"]
-    Verifier["verifier/ Rust Axum :3002"]
-    Redis["Redis 7 receipt store by default\noptional response cache"]
-    AI["AI provider: OpenRouter or Ollama"]
-    Wallet["EVM wallet on configured chain\nBase Sepolia default"]
-
-    Client --> Web
-    Client --> Gateway
-    Web --> Gateway
-    Web -. "switch chain and sign EIP-712" .-> Wallet
-    Gateway --> Verifier
-    Gateway --> AI
-    Gateway -->|"receipts and cache when configured"| Redis
-
-    subgraph Public["Public surface"]
-      Web
-      Gateway
-    end
-
-    subgraph Internal["Internal services"]
-      Verifier
-      Redis
-    end
-```
-
-### Deep System Design
-
-```mermaid
-flowchart TB
-    Browser["Browser wallet UI\nweb/src/app/page.tsx"]
-    CLI["CLI or agent client"]
-
-    subgraph Gateway["gateway/ Go service"]
-      Gin["Gin router"]
-      LoggerRecovery["Gin logger and recovery"]
-      Correlation["Correlation ID middleware"]
-      Compression["gzip middleware"]
-      CORS["CORS allowed origins"]
-      RateLimit["Token bucket rate limiter"]
-      Timeout["Request timeout middleware"]
-      Cache["Optional Redis cache middleware\nbypasses unsigned requests; verifies signed cache hits"]
-      Summarize["POST /api/ai/summarize"]
-      PaymentContext["Create PaymentContext\nrecipient, token, amount, chainId, nonce, timestamp"]
-      VerifyClient["Verifier HTTP client\nVERIFIER_URL"]
-      AIClient["AI provider client\nOpenRouter or Ollama"]
-      ReceiptSigner["Receipt signer\nserver wallet key"]
-      ReceiptLookup["GET /api/receipts/{id}"]
-      Health["/healthz and /readyz"]
-    end
-
-    subgraph VerifierService["verifier/ Rust service"]
-      BodyLimit["Body size limit"]
-      Domain["EIP-712 domain\nname, version, chainId, zero verifyingContract"]
-      Timestamp["Timestamp expiry and clock skew checks"]
-      Nonce["Nonce replay guard\nmemory or Redis"]
-      Recovery["ECDSA recovery"]
-      VerifyRoute["POST /verify"]
-    end
-
-    subgraph Storage["Redis 7"]
-      Receipts["receipt:{id}\nRedis receipt store by default"]
-      ResponseCache["ai:summary:{hash}\noptional cached summaries"]
-    end
-
-    MemoryStore["In-memory receipt store\nquick start and tests when RECEIPT_STORE=memory"]
-
-    subgraph Providers["AI providers"]
-      OpenRouter["OpenRouter chat completions"]
-      Ollama["Local Ollama generate API"]
-    end
-
-    Browser --> Gin
-    CLI --> Gin
-    Gin --> LoggerRecovery --> Correlation --> Compression --> CORS --> RateLimit --> Timeout --> Cache
-    Cache -->|cache miss or disabled| Summarize
-    Cache -->|signed cache hit| VerifyClient
-    Summarize -->|missing X-402 headers| PaymentContext
-    PaymentContext --> Browser
-    PaymentContext --> CLI
-    Summarize -->|signed retry| VerifyClient --> VerifyRoute
-    VerifyRoute --> BodyLimit --> Domain --> Timestamp --> Nonce --> Recovery
-    Recovery -->|valid or structured error_code| VerifyClient
-    Summarize -->|verified cache miss| AIClient
-    AIClient --> OpenRouter
-    AIClient --> Ollama
-    Summarize --> ReceiptSigner --> Receipts
-    ReceiptSigner --> MemoryStore
-    Cache -->|cached response receipt| ReceiptSigner
-    Cache <--> ResponseCache
-    ReceiptLookup --> Receipts
-    ReceiptLookup --> MemoryStore
-    Gin --> Health
-```
-
-### x402-Style Payment Flow
+## How it works
 
 ```mermaid
 sequenceDiagram
     participant C as Client
-    participant G as Gateway
-    participant V as Verifier
-    participant A as AI Provider
-    participant R as Receipt Store / Optional Cache
+    participant G as Go gateway
+    participant V as Rust verifier
+    participant A as AI provider
+    participant R as Receipt store
 
     C->>G: POST /api/ai/summarize
-    G-->>C: 402 + paymentContext(recipient, token, amount, chainId, nonce, timestamp)
-    C->>C: Sign EIP-712 Payment typed data
-    C->>G: Retry with X-402-Signature, X-402-Nonce, X-402-Timestamp
-    G->>V: POST /verify with reconstructed context + signature
-    V-->>G: is_valid + recovered_address or structured error_code
-    alt Redis response cache hit
-      G->>R: Read cached summary after verification
-    else Cache miss or cache disabled
-      G->>A: Generate summary
-      A-->>G: Summary text
-      opt CACHE_ENABLED=true
-        G->>R: Store cached summary
-      end
-    end
-    G->>G: Sign receipt over request/response hashes
-    G->>R: Store receipt with TTL
-    G-->>C: 200 { result } + X-402-Receipt
+    G-->>C: 402 + paymentContext
+    C->>C: Sign EIP-712 Payment
+    C->>G: Retry with X-402-* headers
+    G->>V: Verify signature and context
+    V-->>G: Recovered wallet or rejection
+    G->>A: Generate summary
+    A-->>G: Summary
+    G->>R: Store signed receipt
+    G-->>C: 200 result + X-402-Receipt
 ```
 
-### Receipt Lifecycle
+The signed context binds the recipient, token, amount, nonce, timestamp, and chain ID. The verifier rejects malformed signatures, wrong chains, stale or future timestamps, and replayed nonces before the gateway calls the AI provider.
+
+## Architecture
 
 ```mermaid
 flowchart LR
-    Success["Successful signed request"]
-    Receipt["SignedReceipt JSON"]
-    Header["Base64 X-402-Receipt header only"]
-    Store["Receipt store: Redis by default, memory for quick start/tests"]
-    Lookup["GET /api/receipts/{id}"]
-    Verify["Client can verify signature with sdk/typescript"]
+    Browser["Web app<br/>Next.js :3001"]
+    SDK["TypeScript SDK"]
+    Gateway["API gateway<br/>Go + Gin :3000"]
+    Verifier["Signature verifier<br/>Rust + Axum :3002"]
+    AI["OpenRouter or Ollama"]
+    Redis["Redis<br/>nonces, receipts, optional cache"]
 
-    Success --> Receipt
-    Receipt --> Header
-    Receipt --> Store
-    Store --> Lookup
-    Header --> Verify
-    Lookup --> Verify
+    Browser --> Gateway
+    SDK --> Gateway
+    Gateway --> Verifier
+    Gateway --> AI
+    Gateway <--> Redis
+    Verifier <--> Redis
 ```
 
-## Getting Started Local
+| Component | Responsibility |
+| --- | --- |
+| [`gateway/`](gateway/) | Public API, payment challenges, verifier orchestration, provider calls, receipts, cache, limits, and metrics. |
+| [`verifier/`](verifier/) | EIP-712 recovery, chain and timestamp enforcement, and memory- or Redis-backed nonce replay protection. |
+| [`web/`](web/) | Wallet detection, chain switching, signing, paid retry UX, receipt display, and browser documentation. |
+| [`sdk/typescript/`](sdk/typescript/) | Programmatic challenge handling, typed-data signing, retries, receipt decoding, and trusted-key verification. |
+| [`tests/`](tests/) | End-to-end unsigned challenge, signed retry, verifier acceptance, receipt, and replay checks. |
+
+## Quick start
 
 ### Prerequisites
 
-| Tool | Version | Used by |
-| --- | --- | --- |
-| Bun | `1.3.13+` recommended | Root scripts, web install/build, E2E tests |
-| Go | `1.24.x` | Gateway |
-| Rust | Stable | Verifier |
-| Docker | Optional | Compose stack and Redis |
-| Redis | Optional for quick start | Required for Docker/production-style Redis receipts |
+| Tool | Version |
+| --- | --- |
+| [Bun](https://bun.sh/) | `1.3.13+` |
+| [Go](https://go.dev/) | `1.24.x` |
+| [Rust](https://www.rust-lang.org/tools/install) | Stable |
+| Docker and Redis | Optional; used for the Compose stack and shared persistence |
 
 ### Install
-
-> **Note:** Ensure Bun is installed before running the installation commands, as it is required for dependency installation and project scripts.
 
 ```bash
 git clone https://github.com/AnkanMisra/MicroAI-Paygate.git
@@ -230,52 +121,78 @@ bun install
 (cd web && bun install)
 (cd gateway && go mod download)
 (cd verifier && cargo build -q)
-```
-
-### Configure
-
-```bash
 cp .env.example .env
 ```
 
-Edit `.env` before starting the gateway. At minimum:
+Set these development values in `.env`:
 
-- `OPENROUTER_API_KEY`: required when `AI_PROVIDER=openrouter`.
-- `SERVER_WALLET_PRIVATE_KEY`: required for signing receipts. Use an unfunded development key locally.
-- `RECIPIENT_ADDRESS`: recipient address embedded in payment contexts.
-- `CHAIN_ID` and `EXPECTED_CHAIN_ID`: must match. The default is `84532` for Base Sepolia.
-The root `bun run stack` command starts the gateway with `RECEIPT_STORE=memory` and `CACHE_ENABLED=false` unless you exported different values in the shell. That means the normal quick start does not require Redis even though production-style receipt storage defaults to Redis.
+- `OPENROUTER_API_KEY` when using the default OpenRouter provider.
+- `SERVER_WALLET_PRIVATE_KEY` to an **unfunded development key** used only for receipt signing.
+- `RECIPIENT_ADDRESS` to the payment recipient shown in challenges.
+- `CHAIN_ID` and `EXPECTED_CHAIN_ID` to the same chain; the default is Base Sepolia (`84532`).
 
-### Run The Stack
+Never use a funded wallet, seed phrase, production key, or real secret in local examples.
+
+### Run without Redis
+
+The example environment intentionally selects Redis-backed production-style stores. Override both stores for the lightweight local stack:
 
 ```bash
+RECEIPT_STORE=memory \
+VERIFIER_NONCE_STORE=memory \
+CACHE_ENABLED=false \
 bun run stack
 ```
 
-Services:
+Open:
 
-- Gateway: `http://localhost:3000`
-- Gateway Swagger UI: `http://localhost:3000/docs`
-- Web: `http://localhost:3001`
-- Verifier: `http://localhost:3002/health`
+- Web app: <http://localhost:3001>
+- Gateway: <http://localhost:3000>
+- Swagger UI: <http://localhost:3000/docs>
+- Verifier health: <http://localhost:3002/health>
 
-### Use The SDK
+### Run with Docker Compose
 
-The local TypeScript SDK lives in [sdk/typescript/](sdk/typescript). It mirrors the current custom x402-style gateway protocol and is private for now; it is not published to npm.
+The Compose stack starts all services with Redis-backed receipts and verifier nonce protection:
+
+```bash
+docker compose up --build
+```
+
+## API and SDK
+
+### Gateway endpoints
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /api/ai/summarize` | Return a payment challenge or process a signed summarize request. |
+| `GET /api/receipts/{id}` | Fetch a stored signed receipt before its TTL expires. |
+| `GET /healthz` | Gateway liveness. |
+| `GET /readyz` | Verifier, provider, Redis-when-required, and gateway readiness. |
+| `GET /metrics` | Prometheus metrics; configurable with `METRICS_PATH`. |
+| `GET /openapi.yaml` | Raw OpenAPI contract. |
+| `GET /docs` | Swagger UI. |
+
+Signed retries include:
+
+```http
+X-402-Signature: <wallet signature>
+X-402-Nonce: <nonce from paymentContext>
+X-402-Timestamp: <timestamp from paymentContext>
+```
+
+Successful responses return the signed receipt as base64-encoded JSON in `X-402-Receipt`. See [`gateway/openapi.yaml`](gateway/openapi.yaml) for the complete contract.
+
+### TypeScript SDK
+
+The private repo-local package `@microai/paygate-sdk` automates the unsigned request, challenge signing, paid retry, receipt decoding, and trusted-key verification flow.
 
 ```bash
 cd sdk/typescript
 bun install
+bun run typecheck
 bun run test
 ```
-
-Install it into a local app from this repo path before importing the package name:
-
-```bash
-bun add /path/to/MicroAI-Paygate/sdk/typescript
-```
-
-Example app usage:
 
 ```ts
 import { ethers } from "ethers";
@@ -288,158 +205,69 @@ const client = new PaygateClient({
 });
 
 const response = await client.summarize("Text to summarize");
-console.log(response.data.result);
-console.log(response.receiptVerified);
+console.log(response.data.result, response.receiptVerified);
 ```
 
-For the runnable example, set:
-
-```text
-PAYGATE_GATEWAY_URL=http://localhost:3000
-EVM_PRIVATE_KEY=0x...
-PAYGATE_SERVER_PUBLIC_KEY=0x...
-```
-
-Use only unfunded local or test wallets. The SDK signs the same EIP-712 payment context as the web app and E2E tests, retries with the gateway's `X-402-*` headers, decodes `X-402-Receipt`, and verifies the receipt signature locally against the configured gateway receipt signing public key. If no trusted server public key is configured, receipt payload hashes are still checked but `receiptVerified` is `false`. It does not perform official x402 facilitator settlement.
-
-### Docker Compose
-
-Docker Compose starts gateway, verifier, web, and Redis. It uses service names inside the Docker network, so the gateway reaches the verifier at `http://verifier:3002` and Redis at `redis:6379`. Compose defaults the verifier nonce store to Redis so replay protection is shared across verifier replicas; set `VERIFIER_NONCE_STORE=memory` only for local single-process experiments.
-
-```bash
-cp .env.example .env
-docker-compose up --build
-```
+Read the [SDK guide](sdk/typescript/README.md) for local installation, error codes, receipt trust, and live testing.
 
 ## Configuration
 
-Core local variables live in [.env.example](.env.example). Production placeholders live in [.env.production.example](.env.production.example).
+The full local template is [`.env.example`](.env.example); production placeholders are in [`.env.production.example`](.env.production.example).
 
-| Variable | Service | Notes |
-| --- | --- | --- |
-| `AI_PROVIDER` | Gateway | `openrouter` by default, `ollama` for local Ollama experiments. |
-| `OPENROUTER_API_KEY` | Gateway | Required when using OpenRouter. Never commit a real key. |
-| `OPENROUTER_MODEL` | Gateway | OpenRouter model name. Demo docs use `z-ai/glm-4.5-air:free` unless overridden. |
-| `OLLAMA_URL`, `OLLAMA_MODEL` | Gateway | Used only when `AI_PROVIDER=ollama`. |
-| `SERVER_WALLET_PRIVATE_KEY` | Gateway | Signs receipts. Use only unfunded local keys in development. |
-| `RECIPIENT_ADDRESS` | Gateway/Web flow | Embedded in payment contexts returned by the gateway. |
-| `CHAIN_ID` | Gateway/Web flow | EIP-712 chain ID in payment contexts. |
-| `EXPECTED_CHAIN_ID` | Verifier | Verifier enforcement chain. Falls back to `CHAIN_ID` if unset. |
-| `SIGNATURE_EXPIRY_SECONDS` | Verifier | Signature freshness and nonce retention window. Default `300`. |
-| `SIGNATURE_CLOCK_SKEW_SECONDS` | Verifier | Future timestamp grace. Default `60`. |
-| `VERIFIER_NONCE_STORE` | Verifier | `memory` by default for local/tests, `redis` for shared multi-replica nonce replay protection. |
-| `VERIFIER_NONCE_KEY_PREFIX` | Verifier | Redis key prefix for verifier nonce hashes. Default `microai:verifier:nonce:`. |
-| `VERIFIER_REDIS_TIMEOUT_MS` | Verifier | Redis nonce-store connection and claim timeout in milliseconds. Default `2000`. |
-| `RECEIPT_STORE` | Gateway | `redis` by default, `memory` for tests/local experiments. |
-| `REDIS_URL` | Gateway/Verifier | Required when `RECEIPT_STORE=redis`, `CACHE_ENABLED=true`, or `VERIFIER_NONCE_STORE=redis`. |
-| `VERIFIER_URL` | Gateway | **Required.** Where the gateway calls `/verify` (e.g. `http://127.0.0.1:3002` for `bun run stack`, `https://<app>.onrender.com` for Render). The gateway refuses to start if unset — no silent loopback fallback. |
-| `NEXT_PUBLIC_VERIFIER_URL` | Web | Frontend verifier warm-up endpoint used by banner for pre-warming the verifier. |
-| `MAX_REQUEST_BODY_BYTES` | Verifier | Maximum request body size in bytes for verifier. Must be a positive integer; values less than or equal to 0 or invalid values fall back to the default `1048576` (1MB). |
-| `CACHE_ENABLED` | Gateway | Optional response cache. Payment verification still runs on cache hits. |
-| `METRICS_ENABLED` | Gateway | Enables the Prometheus metrics endpoint by default. Set to `false` to disable. |
-| `METRICS_PATH` | Gateway | Gateway metrics path. Default `/metrics`; values without a leading slash are normalized. |
-| `ALLOWED_ORIGINS` | Gateway | Comma-separated CORS origins, no paths or query strings. |
-| `TRUSTED_PROXIES` | Gateway | Comma-separated trusted proxy CIDRs for production IP handling. |
-| `NEXT_PUBLIC_GATEWAY_URL` | Web | Gateway base URL. Browser fetches `/api/ai/summarize` and `/api/receipts/:id` here. |
-| `NEXT_PUBLIC_EXPECTED_CHAIN_ID` | Web | Chain ID the wallet widget targets. Must match the gateway's `CHAIN_ID`. Default `84532`. |
-| `NEXT_PUBLIC_EXPECTED_CHAIN_NAME` | Web | Display name paired with the chain ID — used by the wallet widget's "Switch to <name>" button, hero headline, stat bar, and page title. Must be set when `CHAIN_ID` is overridden (e.g. `Base` for `8453`). |
-| `NEXT_PUBLIC_PAYMENT_AMOUNT` | Web | Pre-challenge fee label shown in the summarize form + stat bar. Display only — the gateway's payment context controls the actual signed amount. Default `0.001`. |
-| `NEXT_PUBLIC_PAYMENT_TOKEN` | Web | Token symbol paired with the amount. Default `USDC`. |
-| `NEXT_PUBLIC_POSTHOG_ENABLED` | Web | Browser analytics kill switch for PostHog Phase 1. Default `false`. |
-| `NEXT_PUBLIC_POSTHOG_PROJECT_TOKEN` | Web | PostHog project token used by the browser SDK when analytics is enabled. |
-| `NEXT_PUBLIC_POSTHOG_HOST` | Web | PostHog ingestion host. Default `https://us.i.posthog.com`. |
-
-## Testing
-
-| Area | Command | Notes |
-| --- | --- | --- |
-| Gateway tests | `cd gateway && go test -v ./...` | Uses miniredis for Redis behavior where needed. |
-| Gateway vet | `cd gateway && go vet ./...` | Run for Go changes. |
-| Verifier tests | `cd verifier && cargo test` | Covers EIP-712, chain ID, timestamp, and nonce behavior. |
-| Verifier lint | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings` | Run for Rust changes. |
-| Web lint/build/typecheck/unit | `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` | `bun run typecheck` is `tsc --noEmit` (`bun run test` is kept as an alias); `bun run test:unit` runs Bun unit tests. |
-| SDK typecheck/tests | `cd sdk/typescript && bun run typecheck && bun run test` | Covers signing parity, signed retry headers, receipt decoding, trusted-key receipt verification, and mocked client flow. |
-| E2E | `bun run test:e2e` | Starts gateway/verifier. Requires `OPENROUTER_API_KEY` for default OpenRouter startup path. |
-| All unit tests | `bun run test:unit` | Gateway plus verifier tests. |
-
-Do not use `bun test` by itself for the project E2E flow. It runs Bun's test runner without starting services.
-
-## Public Gateway API
-
-The gateway serves OpenAPI at `GET /openapi.yaml` and Swagger UI at `GET /docs`.
-
-| Endpoint | Purpose |
+| Variable | Purpose |
 | --- | --- |
-| `GET /healthz` | Liveness check for the gateway process. |
-| `GET /readyz` | Readiness check for verifier, active AI provider, Redis when required, and the gateway's own metrics. |
-| `GET /metrics` | Prometheus metrics for gateway request rate, latency, cache, verification, rate-limit, and active-request signals. |
-| `POST /api/ai/summarize` | Payment-gated text summarization endpoint. |
-| `GET /api/receipts/{id}` | Fetch a stored signed receipt until its TTL expires. |
+| `AI_PROVIDER` | `openrouter` by default or `ollama` for a local provider. |
+| `OPENROUTER_API_KEY`, `OPENROUTER_MODEL` | OpenRouter credentials and model selection. |
+| `SERVER_WALLET_PRIVATE_KEY` | Signs gateway receipts; keep it secret and unfunded in demos. |
+| `RECIPIENT_ADDRESS`, `PAYMENT_AMOUNT` | Values embedded in payment contexts. |
+| `CHAIN_ID`, `EXPECTED_CHAIN_ID` | Gateway and verifier chain IDs; these must match. |
+| `VERIFIER_URL` | Verifier base URL used by the gateway; required at startup. |
+| `VERIFIER_NONCE_STORE` | `memory` locally or `redis` for shared replay protection. |
+| `RECEIPT_STORE` | `memory` locally or `redis` for restart-safe receipts. |
+| `REDIS_URL` | Required by Redis nonce, receipt, or response-cache modes. |
+| `CACHE_ENABLED` | Enables the optional Redis response cache; signed cache hits are still verified. |
+| `NEXT_PUBLIC_GATEWAY_URL` | Browser-visible gateway URL compiled into the web app. |
 
-Signed retries to `POST /api/ai/summarize` must include:
+Service-specific options are documented in the [gateway](gateway/README.md), [verifier](verifier/README.md), and [web](web/README.md) guides.
 
-```http
-X-402-Signature: <wallet signature>
-X-402-Nonce: <nonce from paymentContext>
-X-402-Timestamp: <timestamp from paymentContext>
-```
+## Development
 
-Successful summarize responses return:
+Run the checks for every component you change:
 
-```json
-{
-  "result": "AI summary text..."
-}
-```
-
-The signed receipt is returned in the `X-402-Receipt` response header as base64-encoded `SignedReceipt` JSON.
-
-## Observability
-
-The gateway exposes Prometheus metrics at `GET /metrics` by default. Set `METRICS_ENABLED=false` to disable the endpoint, or set `METRICS_PATH` to move it. The verifier exposes Prometheus metrics at `GET /metrics` on port `3002`.
-
-```yaml
-scrape_configs:
-  - job_name: microai-gateway
-    static_configs:
-      - targets: ["localhost:3000"]
-    metrics_path: /metrics
-
-  - job_name: microai-verifier
-    static_configs:
-      - targets: ["localhost:3002"]
-    metrics_path: /metrics
-```
-
-## Benchmarking
-
-The verifier micro-benchmark lives in [bench/](bench/README.md). It measures only the Rust `/verify` endpoint. It does not measure gateway latency, wallet signing, Redis, OpenRouter, web UI, or the full x402 flow.
-
-Only cite numbers from committed `bench/RESULTS-*.txt` files. The latest committed run is [bench/RESULTS-2026-05-13.txt](bench/RESULTS-2026-05-13.txt):
-
-| Metric | Result |
+| Area | Commands |
 | --- | --- |
-| Requests/sec | `1526.94` |
-| p99 latency | `85.45ms` |
+| Gateway | `cd gateway && go test -v ./... && go vet ./...` |
+| Verifier | `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test` |
+| Web | `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` |
+| SDK | `cd sdk/typescript && bun run typecheck && bun run test` |
+| Unit suite | `bun run test:unit` |
+| E2E | `RECEIPT_STORE=memory VERIFIER_NONCE_STORE=memory CACHE_ENABLED=false bun run test:e2e` — also requires `OPENROUTER_API_KEY` for the default provider |
 
-Current reruns must generate enough one-time signed payloads because verifier nonces are replay-protected.
+> [!TIP]
+> Do not replace `bun run test:e2e` with plain `bun test`; the E2E script builds and starts the gateway and verifier first.
 
-## Known Limitations
+## Deployment
 
-- A valid signature is not on-chain settlement. The verifier proves authorization, not that USDC moved.
-- The current protocol is x402-style, not official x402-compatible. It uses custom `X-402-*` headers and no official facilitator settlement path.
-- Verifier nonce replay protection defaults to memory for local/tests and supports Redis for multi-replica deployments. Invalid signatures are rejected before nonce claims, and Redis outages fail closed.
-- Gateway rate limiting is per process. Horizontal scaling needs distributed limits.
-- `RECEIPT_STORE=redis` is production-style and restart-safe. `RECEIPT_STORE=memory` is for tests and local experiments.
-- The demo defaults to Base Sepolia (`84532`). Multi-chain support would require dynamic EIP-712 domain and config updates across gateway, verifier, web, tests, and docs.
-- Free OpenRouter demo models keep cost low but may produce weak summaries.
+The demo deployment uses Render for the gateway and verifier, Vercel for the web app, and Upstash Redis for shared nonces and signed receipts. Follow [DEPLOY.md](DEPLOY.md) for the platform-specific setup and secret checklist.
 
-## Contributing
+## Project guides
 
-Please read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request. Security-sensitive changes need extra care around EIP-712 parity, timestamps, nonces, chain IDs, receipts, CORS, rate limits, and secret handling.
+| Topic | Guide |
+| --- | --- |
+| Web documentation | Run `cd web && bun run dev`, then open [`/docs`](http://localhost:3001/docs). |
+| Public API | [`gateway/openapi.yaml`](gateway/openapi.yaml) |
+| Contributor workflow | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Security reporting | [`SECURITY.md`](SECURITY.md) |
+| Support | [`SUPPORT.md`](SUPPORT.md) |
+| Repository rules | [`RULES.md`](RULES.md) |
+| Benchmarks | [`bench/README.md`](bench/README.md) |
 
-For normal support, use [SUPPORT.md](SUPPORT.md). For vulnerabilities, use [SECURITY.md](SECURITY.md) and do not disclose exploit details publicly.
+## Current boundaries
 
-## License
+- The protocol uses custom `X-402-*` headers and has no official facilitator adapter.
+- Wallet signatures authorize payment contexts but do not prove on-chain settlement.
+- Gateway rate limits are process-local; horizontally scaled deployments need distributed limits.
+- Memory-backed nonces and receipts are single-process development modes; use Redis for shared or restart-safe state.
+- The default demo chain is Base Sepolia; changing chains requires aligned gateway, verifier, web, SDK, test, and documentation configuration.
 
-MicroAI Paygate is released under the [MIT License](LICENSE).
+If this project helps you, consider starring the repository so more contributors can find it.

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,18 +19,21 @@ The `tests/` directory contains Bun end-to-end coverage for the gateway and veri
 - Ports `3000` and `3002` free
 - `OPENROUTER_API_KEY` for the default OpenRouter gateway startup path
 
-The helper defaults to:
+When these variables are unset, the helper defaults the gateway to:
 
 - `RECEIPT_STORE=memory`
 - `CACHE_ENABLED=false`
 
-Redis is not required unless you override those variables.
+The verifier still honors `VERIFIER_NONCE_STORE` from the environment. If you copied `.env.example`, override its Redis mode when running E2E without Redis.
 
 ## Run
 
 From the repository root:
 
 ```bash
+RECEIPT_STORE=memory \
+VERIFIER_NONCE_STORE=memory \
+CACHE_ENABLED=false \
 bun run test:e2e
 ```
 
@@ -47,7 +50,7 @@ Do not use plain `bun test` as a replacement unless you have already started the
 In one shell:
 
 ```bash
-bun run stack
+RECEIPT_STORE=memory VERIFIER_NONCE_STORE=memory CACHE_ENABLED=false bun run stack
 ```
 
 In another shell:

--- a/web/src/app/docs/architecture/page.mdx
+++ b/web/src/app/docs/architecture/page.mdx
@@ -8,7 +8,7 @@ MicroAI Paygate is split into small services so each trust boundary is visible.
 - `sdk/typescript/`: local TypeScript SDK for AI API builders.
 - `gateway/`: Go/Gin public API gateway on port `3000`.
 - `verifier/`: Rust/Axum EIP-712 verifier on port `3002`.
-- Redis: receipt storage by default and optional response cache.
+- Redis: shared verifier nonce claims, receipt storage, and optional response cache.
 - AI provider: OpenRouter or Ollama depending on configuration.
 
 ## Data Flow
@@ -27,7 +27,7 @@ MicroAI Paygate is split into small services so each trust boundary is visible.
 
 The gateway owns orchestration, rate limiting, timeouts, AI provider calls, receipt signing, receipt storage, and public error mapping.
 
-The verifier owns EIP-712 parity, signer recovery, chain ID enforcement, timestamp freshness, and nonce replay protection for the verifier instance.
+The verifier owns EIP-712 parity, signer recovery, chain ID enforcement, timestamp freshness, and nonce replay protection through either process-local memory or shared Redis.
 
 The web app owns wallet UX, chain switching, user-facing errors, receipt display, and browser-local receipt history.
 

--- a/web/src/app/docs/operations/page.mdx
+++ b/web/src/app/docs/operations/page.mdx
@@ -13,8 +13,9 @@ This page collects the knobs and checks needed to run MicroAI Paygate locally or
 - `CHAIN_ID`: gateway EIP-712 chain ID.
 - `EXPECTED_CHAIN_ID`: verifier chain ID. Falls back to `CHAIN_ID` if unset.
 - `VERIFIER_URL`: where the gateway calls `/verify`.
+- `VERIFIER_NONCE_STORE`: `memory` for one verifier process or `redis` for shared replay protection.
 - `RECEIPT_STORE`: `redis` by default, `memory` for tests and quick local runs.
-- `REDIS_URL`: required when Redis receipts or cache are enabled.
+- `REDIS_URL`: required when verifier nonces, receipts, or response caching use Redis.
 - `CACHE_ENABLED`: optional response cache. Payment verification still runs on cache hits.
 
 ## Provider Modes
@@ -35,11 +36,11 @@ cd verifier && cargo fmt -- --check
 cd verifier && cargo clippy -- -D warnings
 cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build
 cd sdk/typescript && bun run typecheck && bun run test
-bun run test:e2e
+RECEIPT_STORE=memory VERIFIER_NONCE_STORE=memory CACHE_ENABLED=false bun run test:e2e
 bun run test:unit
 ```
 
-`bun run test:e2e` starts gateway and verifier. With the default OpenRouter path, it requires `OPENROUTER_API_KEY`.
+`bun run test:e2e` starts gateway and verifier. The command above overrides the Redis-backed `.env.example` store modes for a no-Redis run. With the default OpenRouter path, it also requires `OPENROUTER_API_KEY`.
 
 ## Troubleshooting
 

--- a/web/src/app/docs/page.mdx
+++ b/web/src/app/docs/page.mdx
@@ -8,7 +8,7 @@ The project is built for AI API builders, hackathon and interview demos, and pro
 
 - A wallet authorized a specific payment context.
 - The gateway accepted a signed retry with `X-402-*` headers.
-- The verifier recovered the signer and rejected replayed nonces for the current verifier instance.
+- The verifier recovered the signer and rejected replayed nonces using the configured memory or Redis store.
 - The gateway signed a receipt over the request and response hashes.
 - A client can verify that receipt with a trusted gateway receipt signing key.
 
@@ -17,7 +17,7 @@ The project is built for AI API builders, hackathon and interview demos, and pro
 - It does not prove on-chain USDC transfer.
 - It is x402-style, not official x402-compatible.
 - It does not use an official facilitator settlement path.
-- It does not yet provide multi-replica nonce replay protection without the planned shared nonce store.
+- Multi-replica replay protection requires `VERIFIER_NONCE_STORE=redis`; the memory mode remains single-process.
 
 ## Start Here
 

--- a/web/src/app/docs/quickstart/page.mdx
+++ b/web/src/app/docs/quickstart/page.mdx
@@ -40,6 +40,9 @@ At minimum, review these values before starting the stack:
 ## Run
 
 ```bash
+RECEIPT_STORE=memory \
+VERIFIER_NONCE_STORE=memory \
+CACHE_ENABLED=false \
 bun run stack
 ```
 
@@ -50,7 +53,7 @@ Local services:
 - Web: `http://localhost:3001`
 - Verifier health: `http://localhost:3002/health`
 
-The root stack command starts the gateway with memory receipt storage and response cache disabled unless you exported different values in the shell. That keeps the quickstart from requiring Redis.
+The copied `.env` selects Redis-backed stores. These shell overrides take precedence over Bun's automatic `.env` loading and keep the quickstart from requiring Redis.
 
 ## First Request
 

--- a/web/src/app/docs/security-limits/page.mdx
+++ b/web/src/app/docs/security-limits/page.mdx
@@ -12,7 +12,7 @@ MicroAI Paygate is useful because it keeps the payment authorization boundary ex
 
 ## Current Limits
 
-Replay protection is in memory for one verifier instance. Multi-replica production needs a shared nonce store before claiming horizontally scalable replay protection.
+Replay protection supports process-local memory and shared Redis. Multi-replica deployments must use `VERIFIER_NONCE_STORE=redis`; memory mode protects only one verifier process.
 
 A valid signature proves wallet authorization for a payment context. It does not prove USDC moved on-chain.
 
@@ -34,8 +34,6 @@ Planned hardening work should land before stronger production claims:
 
 - Deterministic mock AI provider for demos and CI.
 - Web dogfooding of the local SDK.
-- Structured JSON logs and correlation IDs.
-- Redis-backed verifier nonce storage.
-- Prometheus metrics.
+- Structured JSON logs. Correlation IDs are already propagated across the web, gateway, and verifier request path.
 - Official x402 adapter and facilitator semantics.
 - Optional on-chain USDC settlement.


### PR DESCRIPTION
## Summary

- rebuild the root README around verified project behavior, architecture, setup, API, SDK, and deployment guidance
- correct no-Redis startup and E2E commands by overriding receipt, nonce, and cache modes
- synchronize contributor, test, and web documentation with Redis-backed verifier replay protection
- remove stale roadmap claims for features that are already implemented

## Why

The existing documentation had grown repetitive and contained setup guidance that conflicted with Bun loading `.env`, causing copied Redis defaults to affect supposedly no-Redis commands. This update makes the main entry point concise and keeps related documentation aligned with current code and configuration.

## Validation

- `cd gateway && go test ./... && go vet ./...`
- `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test`
- `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build`
- `cd sdk/typescript && bun run typecheck && bun run test`
- Markdown lint, tracked documentation links, README anchors, GitHub Markdown rendering, and Compose YAML parsing

Docker Compose runtime validation was not run because Docker is unavailable on this machine; the Compose YAML parsed successfully.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rebuilds the project documentation around the current local, E2E, and deployment behavior.

- Adds explicit no-Redis stack and E2E commands.
- Documents memory and Redis verifier nonce modes.
- Consolidates README setup, API, SDK, configuration, and deployment guidance.
- Updates web documentation and contributor instructions.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after clarifying the optional metrics route.

- The no-Redis commands preserve shell overrides through the stack and E2E launch paths.
- The replay-protection guidance matches the memory and Redis verifier modes.
- The metrics table should state that the route can be disabled.

README.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Rebuilds the primary setup, API, SDK, configuration, and deployment guide. |
| CONTRIBUTING.md | Updates contributor setup and E2E commands for explicit local memory stores. |
| tests/README.md | Aligns E2E instructions with the verifier nonce-store configuration. |
| web/src/app/docs/quickstart/page.mdx | Updates the web quickstart with no-Redis startup overrides. |
| web/src/app/docs/security-limits/page.mdx | Documents the Redis requirement for multi-replica replay protection. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ankanmisra%2Fmicroai-paygate%22%20on%20the%20existing%20branch%20%22codex%2Fnext-task%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fnext-task%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A172%0A**Metrics%20route%20can%20be%20disabled**%0A%0AWhen%20%60METRICS_ENABLED%3Dfalse%60%2C%20the%20gateway%20does%20not%20register%20this%20route%20and%20%60GET%20%2Fmetrics%60%20returns%20404.%20The%20endpoint%20table%20presents%20it%20as%20unconditional%2C%20so%20Prometheus%20setup%20based%20on%20this%20README%20can%20fail%20in%20deployments%20that%20intentionally%20disable%20metrics.%0A%0A%60%60%60suggestion%0A%7C%20%60GET%20%2Fmetrics%60%20%7C%20Prometheus%20metrics%20when%20%60METRICS_ENABLED%60%20is%20enabled%3B%20configurable%20with%20%60METRICS_PATH%60.%20%7C%0A%60%60%60%0A%0A&repo=ankanmisra%2Fmicroai-paygate&pr=285&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:172
**Metrics route can be disabled**

When `METRICS_ENABLED=false`, the gateway does not register this route and `GET /metrics` returns 404. The endpoint table presents it as unconditional, so Prometheus setup based on this README can fail in deployments that intentionally disable metrics.

```suggestion
| `GET /metrics` | Prometheus metrics when `METRICS_ENABLED` is enabled; configurable with `METRICS_PATH`. |
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: rebuild project documentation"](https://github.com/ankanmisra/microai-paygate/commit/334f4044f1a6a79fa562bc0877e044d23640d21c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43751876)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->