### PR TITLE
chore: split Go minor dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,8 @@ updates:
     open-pull-requests-limit: 5
     labels: ["dependencies", "go"]
     groups:
-      go-minor-and-patch:
-        update-types: ["minor", "patch"]
+      go-patch:
+        update-types: ["patch"]
 
   # Rust dependencies
   - package-ecosystem: "cargo"


### PR DESCRIPTION
## Summary

- Group only Go patch dependency updates.
- Let Go minor updates open as independent PRs.
- Preserve the documented Go 1.24 baseline.

## Type Of Change

- [x] Deployment/config

## Affected Areas

- [x] Deployment/config (`deploy/`, Docker, env, workflows)

## Contributor Checklist

- [x] I kept the change focused and avoided unrelated refactors.
- [x] I updated README/service docs/OpenAPI/env examples when behavior, config, headers, status codes, or public APIs changed. No documentation update is needed because the Go baseline remains unchanged.
- [x] I did not commit secrets, private keys, funded wallets, API keys, or real production URLs.
- [x] I checked x402/EIP-712 field parity when touching payment context, signatures, timestamps, nonces, chain IDs, receipts, or wallet flow. No payment protocol files changed.
- [x] I checked Docker/Compose/Fly/Vercel docs when touching ports, service names, health checks, or environment variables. None changed.

## Verification

```text
git diff --check — passed
Ruby YAML parse — passed
Go group assertion for update-types: ["patch"] — passed
Automation Validation — passed
Dependency Review — passed
CodeQL (Go, JavaScript/TypeScript, Rust) — passed
```

## Notes For Reviewers

PR #286 grouped five upgrades, raised the module to Go 1.25, and failed the Go jobs and dependency review. After this policy change merges, #286 will be closed so Dependabot can recreate compatible updates separately. The five-PR limit remains intentional to cap dependency-review noise.