### PR TITLE
chore: hold Go 1.25-only dependency releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,18 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "go"]
+    # Hold releases that cannot pass the documented Go 1.24 CI/security policy.
+    # Reassess each exact version when the project moves to Go 1.25.
+    ignore:
+      - dependency-name: "github.com/gin-contrib/cors"
+        versions: ["1.7.7"]
+      - dependency-name: "github.com/gin-contrib/gzip"
+        versions: ["1.2.6"]
+      - dependency-name: "github.com/gin-gonic/gin"
+        versions: ["1.12.0"]
+      # v1.17.4 pins x/crypto v0.48; fixed x/crypto releases require Go 1.25.
+      - dependency-name: "github.com/ethereum/go-ethereum"
+        versions: ["1.17.4"]
     groups:
       go-patch:
         update-types: ["patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,14 @@ updates:
     # Reassess each exact version when the project moves to Go 1.25.
     ignore:
       - dependency-name: "github.com/gin-contrib/cors"
-        versions: ["1.7.7"]
+        versions: ["v1.7.7"]
       - dependency-name: "github.com/gin-contrib/gzip"
-        versions: ["1.2.6"]
+        versions: ["v1.2.6"]
       - dependency-name: "github.com/gin-gonic/gin"
-        versions: ["1.12.0"]
+        versions: ["v1.12.0"]
       # v1.17.4 pins x/crypto v0.48; fixed x/crypto releases require Go 1.25.
       - dependency-name: "github.com/ethereum/go-ethereum"
-        versions: ["1.17.4"]
+        versions: ["v1.17.4"]
     groups:
       go-patch:
         update-types: ["patch"]


### PR DESCRIPTION
## Summary

- Hold the exact Gin/CORS/gzip releases that require Go 1.25.
- Hold go-ethereum 1.17.4 because it pins a vulnerable x/crypto release whose fixes require Go 1.25.
- Keep future dependency versions eligible for Dependabot review.

## Type Of Change

- [x] Deployment/config

## Affected Areas

- [x] Deployment/config (`deploy/`, Docker, env, workflows)

## Contributor Checklist

- [x] I kept the change focused and avoided unrelated refactors.
- [x] I updated README/service docs/OpenAPI/env examples when behavior, config, headers, status codes, or public APIs changed. The documented Go baseline remains unchanged.
- [x] I did not commit secrets, private keys, funded wallets, API keys, or real production URLs.
- [x] I checked x402/EIP-712 field parity when touching payment protocol files. No payment protocol files changed.
- [x] I checked deployment docs when touching ports, services, or environment variables. None changed.

## Verification

```text
git diff --check — passed
Dependabot YAML parse and exact-version assertions — passed
node --test .github/scripts/*.test.js — 16 passed
actionlint v1.7.7 — passed
Upstream module checks with Go 1.24.13 — Gin/CORS/gzip require Go 1.25
```

## Notes For Reviewers

PR #292 requires Go 1.25. PR #294 introduces x/crypto 0.48, which fails dependency review; x/crypto 0.49 and newer require Go 1.25. These are exact-version holds and should be removed or updated during the dedicated Go 1.25 migration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore Go 1.25-only dependency releases in Dependabot for /gateway
> Updates [dependabot.yml](.github/dependabot.yml) to ignore specific versions of `gin-contrib/cors`, `gin-contrib/gzip`, `gin-gonic/gin`, and `go-ethereum` that require Go 1.25, which is not yet supported in CI. Dependabot will skip these releases and not open PRs for them until the Go version requirement is met.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0865f62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds exact Dependabot holds for Go dependency releases that are not compatible with the current Go baseline.

- Holds Gin, CORS, and gzip releases requiring Go 1.25.
- Holds the specified go-ethereum release.
- Leaves future dependency versions eligible for updates.

<h3>Confidence Score: 5/5</h3>

The updated Dependabot version patterns should be verified before merging.

- The exact ignore values may not match Go module version strings when they omit the leading `v`.
- Other update settings remain unchanged.

.github/dependabot.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds exact-version ignore rules to the gateway Go-module Dependabot configuration. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ankanmisra%2Fmicroai-paygate%22%20on%20the%20existing%20branch%20%22agent%2Fhold-go125-dependencies%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fhold-go125-dependencies%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A13-21%0A**Go%20version%20holds%20may%20not%20match**%0A%0AGo%20module%20versions%20are%20tagged%20with%20a%20leading%20%60v%60%2C%20while%20every%20exact%20ignore%20pattern%20omits%20it.%20If%20Dependabot%20compares%20the%20configured%20value%20to%20the%20module%20version%20string%20directly%2C%20none%20of%20these%20entries%20match%20and%20it%20will%20continue%20opening%20updates%20for%20the%20releases%20this%20change%20is%20intended%20to%20hold.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20-%20dependency-name%3A%20%22github.com%2Fgin-contrib%2Fcors%22%0A%20%20%20%20%20%20%20%20versions%3A%20%5B%22v1.7.7%22%5D%0A%20%20%20%20%20%20-%20dependency-name%3A%20%22github.com%2Fgin-contrib%2Fgzip%22%0A%20%20%20%20%20%20%20%20versions%3A%20%5B%22v1.2.6%22%5D%0A%20%20%20%20%20%20-%20dependency-name%3A%20%22github.com%2Fgin-gonic%2Fgin%22%0A%20%20%20%20%20%20%20%20versions%3A%20%5B%22v1.12.0%22%5D%0A%20%20%20%20%20%20%23%20v1.17.4%20pins%20x%2Fcrypto%20v0.48%3B%20fixed%20x%2Fcrypto%20releases%20require%20Go%201.25.%0A%20%20%20%20%20%20-%20dependency-name%3A%20%22github.com%2Fethereum%2Fgo-ethereum%22%0A%20%20%20%20%20%20%20%20versions%3A%20%5B%22v1.17.4%22%5D%0A%60%60%60%0A%0A&repo=ankanmisra%2Fmicroai-paygate&pr=295&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/dependabot.yml:13-21
**Go version holds may not match**

Go module versions are tagged with a leading `v`, while every exact ignore pattern omits it. If Dependabot compares the configured value to the module version string directly, none of these entries match and it will continue opening updates for the releases this change is intended to hold.

```suggestion
      - dependency-name: "github.com/gin-contrib/cors"
        versions: ["v1.7.7"]
      - dependency-name: "github.com/gin-contrib/gzip"
        versions: ["v1.2.6"]
      - dependency-name: "github.com/gin-gonic/gin"
        versions: ["v1.12.0"]
      # v1.17.4 pins x/crypto v0.48; fixed x/crypto releases require Go 1.25.
      - dependency-name: "github.com/ethereum/go-ethereum"
        versions: ["v1.17.4"]
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: hold Go 1.25-only dependency rele..."](https://github.com/ankanmisra/microai-paygate/commit/206e758e734abb4b227e49f3068183bac3e3edf4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43869388)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->