### PR TITLE
chore: hold unsafe go-ethereum v1.17.3 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,9 @@ updates:
         versions: ["v1.2.6"]
       - dependency-name: "github.com/gin-gonic/gin"
         versions: ["v1.12.0"]
-      # v1.17.4 pins x/crypto v0.48; fixed x/crypto releases require Go 1.25.
+      # v1.17.3-v1.17.4 pin vulnerable x/crypto releases; fixes require Go 1.25.
       - dependency-name: "github.com/ethereum/go-ethereum"
-        versions: ["v1.17.4"]
+        versions: ["v1.17.3", "v1.17.4"]
     groups:
       go-patch:
         update-types: ["patch"]


### PR DESCRIPTION
## Summary

- ignore go-ethereum `v1.17.3` in addition to `v1.17.4`
- keep older compatible releases eligible for Dependabot updates

## Why

PR #296 shows that `v1.17.3` raises `golang.org/x/crypto` to `v0.47.0`. Dependency review rejects that version for multiple critical, high, and moderate advisories. The fixed x/crypto line requires Go 1.25, while this repository intentionally remains on Go 1.24.

## Validation

- parsed `.github/dependabot.yml` and asserted the exact hold list
- `node --test .github/scripts/*.test.js` (16 passed)
- `actionlint` v1.7.7

Co-authored-by: codex <codex@users.noreply.github.com>

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block go-ethereum v1.17.3 from dependabot updates alongside v1.17.4
> Extends the dependabot ignore list in [dependabot.yml](.github/dependabot.yml) to cover `github.com/ethereum/go-ethereum` v1.17.3, which pins a vulnerable `x/crypto` release. Previously only v1.17.4 was blocked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 42ea6d8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands the Dependabot hold for unsafe go-ethereum releases.

- Ignores go-ethereum v1.17.3 and v1.17.4.
- Updates the reason for the version hold.

<h3>Confidence Score: 5/5</h3>

The changed hold is mergeable after confirming the earlier v1.17 releases remain compatible with Go 1.24.

- The exact-version ignore entries preserve updates to other releases.
- Earlier v1.17 releases remain eligible and should be checked against the stated Go and dependency constraints.

.github/dependabot.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds v1.17.3 to the existing go-ethereum Dependabot hold and updates its explanatory comment. |

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22ankanmisra%2Fmicroai-paygate%22%20on%20the%20existing%20branch%20%22agent%2Fhold-unsafe-geth-1173%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22agent%2Fhold-unsafe-geth-1173%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fdependabot.yml%3A21%0A**Earlier%201.17%20releases%20remain%20eligible**%0A%0AIf%20%60v1.17.0%60%20through%20%60v1.17.2%60%20also%20resolve%20to%20an%20%60x%2Fcrypto%60%20version%20that%20requires%20Go%201.25%20or%20carries%20the%20same%20advisory%20exposure%2C%20Dependabot%20can%20still%20propose%20one%20of%20those%20upgrades%20from%20the%20current%20%60v1.16.8%60%20dependency.%20The%20gateway%20CI%20uses%20Go%201.24%2C%20so%20that%20update%20would%20either%20fail%20its%20build%20or%20reintroduce%20the%20dependency-review%20rejection%20this%20hold%20is%20intended%20to%20prevent.%0A%0A&repo=ankanmisra%2Fmicroai-paygate&pr=297&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/dependabot.yml:21
**Earlier 1.17 releases remain eligible**

If `v1.17.0` through `v1.17.2` also resolve to an `x/crypto` version that requires Go 1.25 or carries the same advisory exposure, Dependabot can still propose one of those upgrades from the current `v1.16.8` dependency. The gateway CI uses Go 1.24, so that update would either fail its build or reintroduce the dependency-review rejection this hold is intended to prevent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: hold unsafe go-ethereum release"](https://github.com/ankanmisra/microai-paygate/commit/42ea6d81c9e476dc128027d68719bd92024fb051) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43872308)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->