### PR TITLE
fix: prevent welcome workflow from being skipped

### DIFF
--- a/.github/workflows/welcome-contributor.yml
+++ b/.github/workflows/welcome-contributor.yml
@@ -14,10 +14,6 @@ concurrency:
 
 jobs:
   welcome:
-    if: >-
-      github.event.pull_request.user.type != 'Bot' &&
-      (github.event.pull_request.author_association == 'FIRST_TIMER' ||
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted automation


### PR DESCRIPTION
## Summary

- remove the duplicated job-level first-contributor condition
- keep eligibility and duplicate-comment checks in the tested trusted script

## Root cause

PR #304 is classified as FIRST_TIME_CONTRIBUTOR, but GitHub evaluated the workflow job condition as false and skipped the job before assigning a runner. Because the same condition already exists in the script, the outer gate is unnecessary and prevents the tested logic from running.

## Impact

First-time contributor PRs will start the welcome job. Bots, returning contributors, and already-welcomed PRs will still be skipped safely by the script.

## Verification

- node --test .github/scripts/*.test.js
- go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
- git diff --check

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix welcome workflow job to run for all contributor PRs
> Removes the `if` condition on the `welcome` job in [welcome-contributor.yml](https://github.com/AnkanMisra/MicroAI-Paygate/pull/305/files#diff-26a8bf41b3f47aaff66bf3b77e84a7eec19a782fdc451a942c33c3375265f67b) that restricted execution to non-bot, first-time contributors. The job now runs whenever the workflow triggers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a2d7617.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor welcome automation to run whenever a pull request is opened.
  * Welcome messages are no longer limited to first-time contributors or non-bot users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves welcome eligibility checks into the trusted workflow script.

- Removes the duplicate job-level contributor condition.
- Keeps bot, eligibility, and duplicate-comment checks in the script.
- Continues to run only for newly opened pull requests.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/welcome-contributor.yml | Removes the workflow-level eligibility gate so the trusted script makes the welcome decision. |

<sub>Reviews (1): Last reviewed commit: ["fix: prevent welcome workflow from being..."](https://github.com/ankanmisra/microai-paygate/commit/a2d76179010ef734f1ec23d9658207e30e6641e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44139022)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/ankanmisra/github/ankanmisra/microai-paygate/-/custom-context?memory=5c18a63b-cbf8-43f9-a5ef-3a97eecfc5ed))
- Context used - Prioritize correctness, security, regressions, mis... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->