### PR TITLE
feat: prepare request-bound payment authorization v2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ VERIFIER_REDIS_TIMEOUT_MS=2000
 
 # Service URLs (for Docker/production)
 VERIFIER_URL=http://127.0.0.1:3002
+# Public gateway origin reserved for the request-bound authorization v2 cutover.
+# Set only the origin (scheme + host + optional port), with no path/query/fragment.
+# The current v1 gateway does not read this value yet.
+# PAYGATE_AUDIENCE=http://localhost:3000
 
 # Maximum allowed request body size in bytes for verifier
 # Default: 1048576 (1MB)

--- a/.env.production.example
+++ b/.env.production.example
@@ -12,6 +12,9 @@ SERVER_WALLET_PRIVATE_KEY=<your-demo-server-wallet-private-key>
 # The gateway normalizes this on startup, but storing it canonically up
 # front avoids the warning log on every boot.
 RECIPIENT_ADDRESS=<your-base-sepolia-recipient-address>
+# Public gateway origin for request-bound authorization v2. Configure this now;
+# it becomes enforced when the gateway v2 cutover is deployed.
+PAYGATE_AUDIENCE=https://<gateway-app>.onrender.com
 PAYMENT_AMOUNT=0.001
 
 REDIS_URL=<your-upstash-redis-url>

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'verifier/**'
+      - 'tests/fixtures/payment-authorization-v2.json'
       - 'deploy/fly/verifier.fly.toml'
       - 'docker-compose.yml'
       - '.github/workflows/rust-tests.yml'
@@ -11,6 +12,7 @@ on:
     branches: [main]
     paths:
       - 'verifier/**'
+      - 'tests/fixtures/payment-authorization-v2.json'
       - 'deploy/fly/verifier.fly.toml'
       - 'docker-compose.yml'
       - '.github/workflows/rust-tests.yml'

--- a/.github/workflows/web-lint-build.yml
+++ b/.github/workflows/web-lint-build.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'web/**'
+      - 'tests/fixtures/payment-authorization-v2.json'
       - 'docker-compose.yml'
       - '.github/workflows/web-lint-build.yml'
   push:
     branches: [main]
     paths:
       - 'web/**'
+      - 'tests/fixtures/payment-authorization-v2.json'
       - 'docker-compose.yml'
       - '.github/workflows/web-lint-build.yml'
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ sequenceDiagram
 
 The signed context binds the recipient, token, amount, nonce, timestamp, and chain ID. The verifier rejects malformed signatures, wrong chains, stale or future timestamps, and replayed nonces before the gateway calls the AI provider.
 
+Request-bound authorization v2 is being rolled out in stages. The verifier, browser, and TypeScript SDK can already validate the v2 audience, method, encoded resource, content type, exact serialized body hash, and claimed payer; the public gateway continues issuing v1 contexts until the cutover is deployed.
+
 ## Architecture
 
 ```mermaid
@@ -229,6 +231,7 @@ The full local template is [`.env.example`](.env.example); production placeholde
 | `RECIPIENT_ADDRESS`, `PAYMENT_AMOUNT` | Values embedded in payment contexts. |
 | `CHAIN_ID`, `EXPECTED_CHAIN_ID` | Gateway and verifier chain IDs; these must match. |
 | `VERIFIER_URL` | Verifier base URL used by the gateway; required at startup. |
+| `PAYGATE_AUDIENCE` | Public gateway origin reserved for request-bound authorization v2; configure it before the gateway cutover. |
 | `VERIFIER_NONCE_STORE` | `memory` locally or `redis` for shared replay protection. |
 | `RECEIPT_STORE` | `memory` locally or `redis` for restart-safe receipts. |
 | `REDIS_URL` | Required by Redis nonce, receipt, or response-cache modes. |

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -94,6 +94,7 @@ Common optional variables:
 | `OLLAMA_URL` | `http://localhost:11434` | Used when `AI_PROVIDER=ollama`. |
 | `OLLAMA_MODEL` | `llama2` provider default | Used when `AI_PROVIDER=ollama`. |
 | `VERIFIER_URL` | **required** (no fallback) | Where the gateway calls `/verify`. Use `http://127.0.0.1:3002` for `bun run stack`, `http://verifier:3002` in Compose, the platform's HTTPS URL in production. The gateway refuses to start if unset. |
+| `PAYGATE_AUDIENCE` | unset | Public gateway origin reserved for request-bound authorization v2. Configure the production origin before the gateway cutover; the current v1 gateway does not read it. |
 | `RECIPIENT_ADDRESS` | Development fallback address | Recipient embedded in payment contexts. |
 | `PAYMENT_AMOUNT` | `0.001` | Amount string embedded in payment contexts. |
 | `CHAIN_ID` | `84532` | Base Sepolia by default. Must match verifier `EXPECTED_CHAIN_ID`. |

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -328,6 +328,7 @@ func main() {
 			"X-402-Signature",
 			"X-402-Nonce",
 			"X-402-Timestamp",
+			"X-402-Payer",
 			"X-Correlation-ID",
 		},
 		ExposeHeaders: []string{

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -7,7 +7,7 @@ The SDK handles the existing gateway flow:
 1. Send an unsigned request.
 2. Read the `402 Payment Required` `paymentContext`.
 3. Sign the payment context with EIP-712.
-4. Retry with `X-402-Signature`, `X-402-Nonce`, and `X-402-Timestamp`.
+4. Retry with the signed `X-402-*` headers (v2 also includes the recovered `X-402-Payer`).
 5. Decode the `X-402-Receipt` response header.
 6. Verify the signed receipt locally.
 
@@ -18,6 +18,8 @@ This package is private and local for now. It is not published to npm.
 MicroAI Paygate currently uses a custom x402-style wire contract. It is not official x402-compatible yet because it uses custom `X-402-*` headers and does not perform facilitator-backed or on-chain USDC settlement.
 
 A valid EIP-712 signature proves wallet authorization for the payment context. It does not prove that USDC moved on-chain.
+
+The SDK accepts the current legacy context and the staged request-bound v2 context. For v2 it verifies the audience, method, encoded path and raw query, content type, and SHA-256 hash of the exact serialized body before opening the wallet signature prompt. The public gateway remains on v1 until the separate cutover change is deployed.
 
 ## Install And Test
 

--- a/sdk/typescript/src/__tests__/client-flow.test.ts
+++ b/sdk/typescript/src/__tests__/client-flow.test.ts
@@ -3,9 +3,11 @@ import { ethers } from "ethers";
 import fixture from "../__fixtures__/gateway-receipt.json";
 import authorizationV2Fixture from "../../../../tests/fixtures/payment-authorization-v2.json";
 import {
+  MicroAIPaygateProtocol,
   PaygateClient,
   type PaymentContext,
   type PaymentContextV2,
+  type PaymentRequestBinding,
   type Receipt,
   type SignedReceipt,
 } from "../index";
@@ -168,6 +170,47 @@ describe("PaygateClient request flow", () => {
       client.request({ method: "POST", path: "/api/ai/summarize", body: { text: "tampered" } }),
     ).rejects.toMatchObject({ code: "payment_binding_mismatch" });
     expect(signCalls).toBe(0);
+    expect(calls).toHaveLength(1);
+  });
+
+  it("rejects a mismatched v2 binding even when a custom adapter validation is a no-op", async () => {
+    const context = {
+      ...(authorizationV2Fixture.context as PaymentContextV2),
+      audience: "http://gateway.test",
+      resource: "/api/ai/summarize",
+    };
+    class NoOpValidationProtocol extends MicroAIPaygateProtocol {
+      signCalls = 0;
+
+      override validatePaymentContext(
+        _ctx: PaymentContext,
+        _request: PaymentRequestBinding,
+      ): void {}
+
+      override signPaymentContext(
+        signer: Parameters<MicroAIPaygateProtocol["signPaymentContext"]>[0],
+        ctx: PaymentContext,
+        payer?: string,
+      ): Promise<string> {
+        this.signCalls += 1;
+        return super.signPaymentContext(signer, ctx, payer);
+      }
+    }
+    const protocol = new NoOpValidationProtocol();
+    const { calls, fetcher } = scriptedFetch([
+      jsonResponse({ paymentContext: context }, { status: 402 }),
+    ]);
+    const client = new PaygateClient({
+      gatewayUrl: "http://gateway.test",
+      signer: wallet,
+      fetch: fetcher,
+      protocol,
+    });
+
+    await expect(
+      client.request({ method: "POST", path: "/api/ai/summarize", body: { text: "tampered" } }),
+    ).rejects.toMatchObject({ code: "payment_binding_mismatch" });
+    expect(protocol.signCalls).toBe(0);
     expect(calls).toHaveLength(1);
   });
 

--- a/sdk/typescript/src/__tests__/client-flow.test.ts
+++ b/sdk/typescript/src/__tests__/client-flow.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import { ethers } from "ethers";
 import fixture from "../__fixtures__/gateway-receipt.json";
+import authorizationV2Fixture from "../../../../tests/fixtures/payment-authorization-v2.json";
 import {
   PaygateClient,
   type PaymentContext,
+  type PaymentContextV2,
   type Receipt,
   type SignedReceipt,
 } from "../index";
@@ -114,6 +116,61 @@ function scriptedFetch(responses: Response[]) {
 }
 
 describe("PaygateClient request flow", () => {
+  it("validates a v2 challenge against the exact outgoing request before signing", async () => {
+    const context = {
+      ...(authorizationV2Fixture.context as PaymentContextV2),
+      nonce: "client-v2-binding",
+      audience: "http://gateway.test",
+      resource: "/api/ai/summarize?mode=brief",
+      requestHash: ethers.sha256(ethers.toUtf8Bytes(JSON.stringify({ text: "hello" }))),
+    };
+    const { calls, fetcher } = scriptedFetch([
+      jsonResponse({ paymentContext: context }, { status: 402 }),
+      jsonResponse({ result: "bound" }, { status: 200 }),
+    ]);
+    const client = new PaygateClient({ gatewayUrl: "http://gateway.test", signer: wallet, fetch: fetcher });
+
+    await client.request({
+      method: "POST",
+      path: "/api/ai/summarize?mode=brief",
+      body: { text: "hello" },
+    });
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].init?.body).toBe(calls[0].init?.body);
+    expect(calls[1].init?.headers).toMatchObject({
+      "X-402-Payer": wallet.address,
+    });
+  });
+
+  it("rejects a mismatched v2 request binding before invoking the signer", async () => {
+    const context = {
+      ...(authorizationV2Fixture.context as PaymentContextV2),
+      audience: "http://gateway.test",
+      resource: "/api/ai/summarize",
+    };
+    let signCalls = 0;
+    const { calls, fetcher } = scriptedFetch([
+      jsonResponse({ paymentContext: context }, { status: 402 }),
+    ]);
+    const client = new PaygateClient({
+      gatewayUrl: "http://gateway.test",
+      signer: {
+        async signTypedData() {
+          signCalls += 1;
+          return "0xnever";
+        },
+      },
+      fetch: fetcher,
+    });
+
+    await expect(
+      client.request({ method: "POST", path: "/api/ai/summarize", body: { text: "tampered" } }),
+    ).rejects.toMatchObject({ code: "payment_binding_mismatch" });
+    expect(signCalls).toBe(0);
+    expect(calls).toHaveLength(1);
+  });
+
   it("handles unsigned request, 402 challenge, signed retry, and verified receipt", async () => {
     const requestBody = JSON.stringify({ text: "hello" });
     const responseBody = JSON.stringify({ result: "summarized text" });
@@ -226,6 +283,9 @@ describe("PaygateClient request flow", () => {
       { ...paymentContext, chainId: Number.MAX_SAFE_INTEGER + 1 },
       { ...paymentContext, timestamp: 1766611200.5 },
       { ...paymentContext, timestamp: Number.MAX_SAFE_INTEGER + 1 },
+      { ...paymentContext, authorizationVersion: 3 },
+      { ...paymentContext, audience: "http://gateway.test" },
+      { ...authorizationV2Fixture.context, requestHash: undefined },
     ];
 
     for (const invalidContext of invalidContexts) {

--- a/sdk/typescript/src/__tests__/payment.test.ts
+++ b/sdk/typescript/src/__tests__/payment.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { ethers } from "ethers";
-import { buildSignedHeaders, signPaymentContext, type PaymentContext } from "../index";
+import authorizationV2Fixture from "../../../../tests/fixtures/payment-authorization-v2.json";
+import {
+  buildPaymentTypedData,
+  buildSignedHeaders,
+  signPaymentContext,
+  type PaymentContext,
+  type PaymentContextV2,
+} from "../index";
 
 const wallet = new ethers.Wallet(
   "0x0123456789012345678901234567890123456789012345678901234567890123",
@@ -50,6 +57,33 @@ describe("payment helpers", () => {
     );
 
     expect(recovered).toBe(wallet.address);
+  });
+
+  it("matches the shared request-bound v2 typed-data fixture", async () => {
+    const context = authorizationV2Fixture.context as PaymentContextV2;
+    const typedData = buildPaymentTypedData(context, authorizationV2Fixture.payer);
+
+    expect(ethers.TypedDataEncoder.hash(typedData.domain, typedData.types, typedData.value)).toBe(
+      authorizationV2Fixture.expectedTypedDataDigest,
+    );
+    expect(
+      ethers.verifyTypedData(
+        typedData.domain,
+        typedData.types,
+        typedData.value,
+        authorizationV2Fixture.expectedSignature,
+      ),
+    ).toBe(authorizationV2Fixture.expectedSigner);
+    expect(await signPaymentContext(wallet, context, authorizationV2Fixture.payer)).toBe(
+      authorizationV2Fixture.expectedSignature,
+    );
+    expect(
+      buildSignedHeaders(
+        context,
+        authorizationV2Fixture.expectedSignature,
+        authorizationV2Fixture.payer,
+      ),
+    ).toMatchObject({ "X-402-Payer": authorizationV2Fixture.expectedSigner });
   });
 
   it("buildSignedHeaders emits exactly the current MicroAI X-402 retry headers", () => {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -63,16 +63,24 @@ export class PaygateClient {
     }
 
     const paymentContext = await this.protocol.readPaymentContext(firstResponse);
+    this.protocol.validatePaymentContext?.(paymentContext, {
+      url,
+      method: request.method,
+      contentType: this.requestContentType(firstInit),
+      bodyText: requestBodyText,
+    });
     let signature: string;
+    let payer: string | undefined;
     try {
-      signature = await this.protocol.signPaymentContext(this.signer, paymentContext);
+      payer = await this.protocol.getPayer?.(this.signer, paymentContext);
+      signature = await this.protocol.signPaymentContext(this.signer, paymentContext, payer);
     } catch (error) {
       throw new PaygateSdkError("payment_signature_failed", "Failed to sign payment context", {
         cause: error,
       });
     }
 
-    const signedHeaders = this.protocol.buildSignedHeaders(paymentContext, signature);
+    const signedHeaders = this.protocol.buildSignedHeaders(paymentContext, signature, payer);
     const retryResponse = await this.fetchOrThrow(
       url,
       this.buildRequestInit(request, signedHeaders, requestBodyText),
@@ -131,6 +139,11 @@ export class PaygateClient {
       headers,
       body: requestBodyText,
     };
+  }
+
+  private requestContentType(init: RequestInit): string {
+    const headers = new Headers(init.headers);
+    return headers.get("Content-Type") ?? "";
   }
 
   private async fetchOrThrow(input: RequestInfo | URL, init: RequestInit): Promise<Response> {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -63,7 +63,7 @@ export class PaygateClient {
     }
 
     const paymentContext = await this.protocol.readPaymentContext(firstResponse);
-    this.protocol.validatePaymentContext?.(paymentContext, {
+    this.protocol.validatePaymentContext(paymentContext, {
       url,
       method: request.method,
       contentType: this.requestContentType(firstInit),

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,6 +1,9 @@
 import { ethers } from "ethers";
 import { PaygateSdkError } from "./errors";
-import { MicroAIPaygateProtocol } from "./protocol/microai";
+import {
+  MicroAIPaygateProtocol,
+  validatePaymentContextForRequest,
+} from "./protocol/microai";
 import type {
   FetchLike,
   PaygateProtocolAdapter,
@@ -63,12 +66,14 @@ export class PaygateClient {
     }
 
     const paymentContext = await this.protocol.readPaymentContext(firstResponse);
-    this.protocol.validatePaymentContext(paymentContext, {
+    const requestBinding = {
       url,
       method: request.method,
       contentType: this.requestContentType(firstInit),
       bodyText: requestBodyText,
-    });
+    };
+    validatePaymentContextForRequest(paymentContext, requestBinding);
+    this.protocol.validatePaymentContext(paymentContext, requestBinding);
     let signature: string;
     let payer: string | undefined;
     try {

--- a/sdk/typescript/src/errors.ts
+++ b/sdk/typescript/src/errors.ts
@@ -1,5 +1,6 @@
 export type PaygateSdkErrorCode =
   | "payment_challenge_missing"
+  | "payment_binding_mismatch"
   | "payment_signature_failed"
   | "signed_retry_failed"
   | "receipt_decode_failed"

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -3,6 +3,8 @@ export { PaygateSdkError, type PaygateSdkErrorCode } from "./errors";
 export {
   PAYMENT_DOMAIN_NAME,
   PAYMENT_DOMAIN_VERSION,
+  PAYMENT_DOMAIN_VERSION_V2,
+  PAYMENT_AUTHORIZATION_TYPES,
   PAYMENT_TYPES,
   buildPaymentTypedData,
   buildSignedHeaders,
@@ -17,6 +19,7 @@ export {
 } from "./receipts";
 export {
   MICROAI_NONCE_HEADER,
+  MICROAI_PAYER_HEADER,
   MICROAI_RECEIPT_HEADER,
   MICROAI_SIGNATURE_HEADER,
   MICROAI_TIMESTAMP_HEADER,
@@ -28,6 +31,9 @@ export type {
   PaygateRequest,
   PaygateResponse,
   PaymentContext,
+  PaymentContextV1,
+  PaymentContextV2,
+  PaymentRequestBinding,
   PaymentDetails,
   PaymentSigner,
   Receipt,

--- a/sdk/typescript/src/payment.ts
+++ b/sdk/typescript/src/payment.ts
@@ -1,8 +1,9 @@
 import { ethers } from "ethers";
-import type { PaymentContext, PaymentSigner } from "./protocol/types";
+import type { PaymentContext, PaymentContextV2, PaymentSigner } from "./protocol/types";
 
 export const PAYMENT_DOMAIN_NAME = "MicroAI Paygate";
 export const PAYMENT_DOMAIN_VERSION = "1";
+export const PAYMENT_DOMAIN_VERSION_V2 = "2";
 
 export const PAYMENT_TYPES = {
   Payment: [
@@ -14,7 +15,55 @@ export const PAYMENT_TYPES = {
   ],
 };
 
-export function buildPaymentTypedData(ctx: PaymentContext) {
+export const PAYMENT_AUTHORIZATION_TYPES = {
+  PaymentAuthorization: [
+    { name: "payer", type: "address" },
+    { name: "recipient", type: "address" },
+    { name: "token", type: "string" },
+    { name: "amount", type: "string" },
+    { name: "nonce", type: "string" },
+    { name: "timestamp", type: "uint256" },
+    { name: "audience", type: "string" },
+    { name: "method", type: "string" },
+    { name: "resource", type: "string" },
+    { name: "contentType", type: "string" },
+    { name: "requestHash", type: "bytes32" },
+  ],
+};
+
+export function isPaymentContextV2(ctx: PaymentContext): ctx is PaymentContextV2 {
+  return "authorizationVersion" in ctx && ctx.authorizationVersion === 2;
+}
+
+export function buildPaymentTypedData(ctx: PaymentContext, payer?: string) {
+  if (isPaymentContextV2(ctx)) {
+    if (!payer) {
+      throw new Error("Request-bound payment authorization requires a payer address");
+    }
+    return {
+      domain: {
+        name: PAYMENT_DOMAIN_NAME,
+        version: PAYMENT_DOMAIN_VERSION_V2,
+        chainId: ctx.chainId,
+        verifyingContract: ethers.ZeroAddress,
+      },
+      types: PAYMENT_AUTHORIZATION_TYPES,
+      value: {
+        payer,
+        recipient: ctx.recipient,
+        token: ctx.token,
+        amount: ctx.amount,
+        nonce: ctx.nonce,
+        timestamp: ctx.timestamp,
+        audience: ctx.audience,
+        method: ctx.method,
+        resource: ctx.resource,
+        contentType: ctx.contentType,
+        requestHash: ctx.requestHash,
+      },
+    };
+  }
+
   return {
     domain: {
       name: PAYMENT_DOMAIN_NAME,
@@ -36,15 +85,28 @@ export function buildPaymentTypedData(ctx: PaymentContext) {
 export async function signPaymentContext(
   signer: PaymentSigner,
   ctx: PaymentContext,
+  payer?: string,
 ): Promise<string> {
-  const { domain, types, value } = buildPaymentTypedData(ctx);
+  const resolvedPayer = isPaymentContextV2(ctx) ? payer ?? (await signer.getAddress?.()) : undefined;
+  const { domain, types, value } = buildPaymentTypedData(ctx, resolvedPayer);
   return signer.signTypedData(domain, types, value);
 }
 
-export function buildSignedHeaders(ctx: PaymentContext, signature: string): Record<string, string> {
-  return {
+export function buildSignedHeaders(
+  ctx: PaymentContext,
+  signature: string,
+  payer?: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
     "X-402-Signature": signature,
     "X-402-Nonce": ctx.nonce,
     "X-402-Timestamp": ctx.timestamp.toString(),
   };
+  if (isPaymentContextV2(ctx)) {
+    if (!payer) {
+      throw new Error("Request-bound payment authorization requires a payer address");
+    }
+    headers["X-402-Payer"] = payer;
+  }
+  return headers;
 }

--- a/sdk/typescript/src/protocol/microai.ts
+++ b/sdk/typescript/src/protocol/microai.ts
@@ -1,9 +1,12 @@
+import { ethers } from "ethers";
 import { buildSignedHeaders, signPaymentContext } from "../payment";
 import { decodeReceiptHeader } from "../receipts";
 import { PaygateSdkError } from "../errors";
 import type {
   PaygateProtocolAdapter,
   PaymentContext,
+  PaymentContextV2,
+  PaymentRequestBinding,
   PaymentSigner,
   SignedReceipt,
 } from "./types";
@@ -11,6 +14,7 @@ import type {
 export const MICROAI_SIGNATURE_HEADER = "X-402-Signature";
 export const MICROAI_NONCE_HEADER = "X-402-Nonce";
 export const MICROAI_TIMESTAMP_HEADER = "X-402-Timestamp";
+export const MICROAI_PAYER_HEADER = "X-402-Payer";
 export const MICROAI_RECEIPT_HEADER = "X-402-Receipt";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -21,16 +25,76 @@ function isPositiveSafeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
-function isPaymentContext(value: unknown): value is PaymentContext {
-  if (!isRecord(value)) return false;
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function hasBasePaymentFields(value: Record<string, unknown>): boolean {
   return (
-    typeof value.recipient === "string" &&
-    typeof value.token === "string" &&
-    typeof value.amount === "string" &&
-    typeof value.nonce === "string" &&
+    isNonEmptyString(value.recipient) &&
+    isNonEmptyString(value.token) &&
+    isNonEmptyString(value.amount) &&
+    isNonEmptyString(value.nonce) &&
     isPositiveSafeInteger(value.chainId) &&
     isPositiveSafeInteger(value.timestamp)
   );
+}
+
+function isPaymentContext(value: unknown): value is PaymentContext {
+  if (!isRecord(value)) return false;
+  if (!hasBasePaymentFields(value)) return false;
+  if (value.authorizationVersion === undefined) {
+    return !["audience", "method", "resource", "contentType", "requestHash"].some(
+      (field) => field in value,
+    );
+  }
+  return (
+    value.authorizationVersion === 2 &&
+    isNonEmptyString(value.audience) &&
+    isNonEmptyString(value.method) &&
+    isNonEmptyString(value.resource) &&
+    isNonEmptyString(value.contentType) &&
+    typeof value.requestHash === "string" &&
+    /^0x[0-9a-fA-F]{64}$/.test(value.requestHash)
+  );
+}
+
+export function validatePaymentContextForRequest(
+  ctx: PaymentContext,
+  request: PaymentRequestBinding,
+): void {
+  if (ctx.authorizationVersion !== 2) return;
+
+  const url = new URL(request.url);
+  const expected: Pick<
+    PaymentContextV2,
+    "audience" | "method" | "resource" | "contentType" | "requestHash"
+  > = {
+    audience: url.origin,
+    method: request.method.toUpperCase(),
+    resource: `${url.pathname}${url.search}`,
+    contentType: request.contentType,
+    requestHash: ethers.sha256(
+      request.bodyText === undefined
+        ? new Uint8Array()
+        : ethers.toUtf8Bytes(request.bodyText),
+    ),
+  };
+
+  for (const field of [
+    "audience",
+    "method",
+    "resource",
+    "contentType",
+    "requestHash",
+  ] as const) {
+    if (ctx[field] !== expected[field]) {
+      throw new PaygateSdkError(
+        "payment_binding_mismatch",
+        `Payment challenge ${field} does not match the outgoing request`,
+      );
+    }
+  }
 }
 
 export class MicroAIPaygateProtocol implements PaygateProtocolAdapter {
@@ -59,12 +123,35 @@ export class MicroAIPaygateProtocol implements PaygateProtocolAdapter {
     return paymentContext;
   }
 
-  signPaymentContext(signer: PaymentSigner, ctx: PaymentContext): Promise<string> {
-    return signPaymentContext(signer, ctx);
+  validatePaymentContext(ctx: PaymentContext, request: PaymentRequestBinding): void {
+    validatePaymentContextForRequest(ctx, request);
   }
 
-  buildSignedHeaders(ctx: PaymentContext, signature: string): Record<string, string> {
-    return buildSignedHeaders(ctx, signature);
+  async getPayer(signer: PaymentSigner, ctx: PaymentContext): Promise<string | undefined> {
+    if (ctx.authorizationVersion !== 2) return undefined;
+    if (!signer.getAddress) {
+      throw new PaygateSdkError(
+        "payment_signature_failed",
+        "The signer must expose getAddress() for request-bound authorization",
+      );
+    }
+    return signer.getAddress();
+  }
+
+  signPaymentContext(
+    signer: PaymentSigner,
+    ctx: PaymentContext,
+    payer?: string,
+  ): Promise<string> {
+    return signPaymentContext(signer, ctx, payer);
+  }
+
+  buildSignedHeaders(
+    ctx: PaymentContext,
+    signature: string,
+    payer?: string,
+  ): Record<string, string> {
+    return buildSignedHeaders(ctx, signature, payer);
   }
 
   readReceipt(response: Response): SignedReceipt | null {

--- a/sdk/typescript/src/protocol/types.ts
+++ b/sdk/typescript/src/protocol/types.ts
@@ -1,6 +1,7 @@
 import type { TypedDataDomain, TypedDataField } from "ethers";
 
-export type PaymentContext = {
+export type PaymentContextV1 = {
+  authorizationVersion?: never;
   recipient: string;
   token: string;
   amount: string;
@@ -9,7 +10,32 @@ export type PaymentContext = {
   timestamp: number;
 };
 
+export type PaymentContextV2 = {
+  authorizationVersion: 2;
+  recipient: string;
+  token: string;
+  amount: string;
+  nonce: string;
+  chainId: number;
+  timestamp: number;
+  audience: string;
+  method: string;
+  resource: string;
+  contentType: string;
+  requestHash: string;
+};
+
+export type PaymentContext = PaymentContextV1 | PaymentContextV2;
+
+export type PaymentRequestBinding = {
+  url: string;
+  method: string;
+  contentType: string;
+  bodyText?: string;
+};
+
 export type PaymentSigner = {
+  getAddress?(): Promise<string>;
   signTypedData(
     domain: TypedDataDomain,
     types: Record<string, Array<TypedDataField>>,
@@ -64,7 +90,17 @@ export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promis
 
 export type PaygateProtocolAdapter = {
   readPaymentContext(response: Response): Promise<PaymentContext>;
-  signPaymentContext(signer: PaymentSigner, ctx: PaymentContext): Promise<string>;
-  buildSignedHeaders(ctx: PaymentContext, signature: string): Record<string, string>;
+  validatePaymentContext?(ctx: PaymentContext, request: PaymentRequestBinding): void;
+  getPayer?(signer: PaymentSigner, ctx: PaymentContext): Promise<string | undefined>;
+  signPaymentContext(
+    signer: PaymentSigner,
+    ctx: PaymentContext,
+    payer?: string,
+  ): Promise<string>;
+  buildSignedHeaders(
+    ctx: PaymentContext,
+    signature: string,
+    payer?: string,
+  ): Record<string, string>;
   readReceipt(response: Response): SignedReceipt | null;
 };

--- a/sdk/typescript/src/protocol/types.ts
+++ b/sdk/typescript/src/protocol/types.ts
@@ -90,7 +90,7 @@ export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promis
 
 export type PaygateProtocolAdapter = {
   readPaymentContext(response: Response): Promise<PaymentContext>;
-  validatePaymentContext?(ctx: PaymentContext, request: PaymentRequestBinding): void;
+  validatePaymentContext(ctx: PaymentContext, request: PaymentRequestBinding): void;
   getPayer?(signer: PaymentSigner, ctx: PaymentContext): Promise<string | undefined>;
   signPaymentContext(
     signer: PaymentSigner,

--- a/tests/fixtures/payment-authorization-v2.json
+++ b/tests/fixtures/payment-authorization-v2.json
@@ -1,0 +1,22 @@
+{
+  "bodyText": "{\"text\":\"Hello, request-bound world!\"}",
+  "bodyHex": "0x7b2274657874223a2248656c6c6f2c20726571756573742d626f756e6420776f726c6421227d",
+  "context": {
+    "authorizationVersion": 2,
+    "recipient": "0x2cAF48b4BA1C58721a85dFADa5aC01C2DFa62219",
+    "token": "USDC",
+    "amount": "0.001",
+    "nonce": "request-binding-v2-fixture",
+    "chainId": 84532,
+    "timestamp": 1766611200,
+    "audience": "https://gateway.example.com",
+    "method": "POST",
+    "resource": "/api/ai/summarize?mode=brief&tag=a&tag=b",
+    "contentType": "application/json",
+    "requestHash": "0x8187d0879ad19b46b277e1b761d3f70d51bc9de6459530b686cfaa503ae8d0e9"
+  },
+  "payer": "0x14791697260E4c9A71f18484C9f997B308e59325",
+  "expectedSigner": "0x14791697260E4c9A71f18484C9f997B308e59325",
+  "expectedTypedDataDigest": "0xc80167523dde00caae3e18e67ed31fc3703257a488cd385b93c2c1d20a44bf68",
+  "expectedSignature": "0xd56e5f5319be8e0cb0940a12cf7a76562edd83c83355c2d1101c0b91dfe4f6c37da9e933b8f69128f1ee4df4ccadd17de757b4fd17294502b59afffc4d6c1b331b"
+}

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -12,7 +12,9 @@ The verifier is a Rust/Axum service on port `3002`. It validates EIP-712 payment
 - Reject reused nonce hashes inside the configured signature window.
 - Return structured `error_code` values that the gateway maps to sanitized public errors.
 
-## EIP-712 Domain
+## EIP-712 Domains
+
+Legacy authorizations use this domain:
 
 | Field | Value |
 | --- | --- |
@@ -30,6 +32,24 @@ Payment(
   string amount,
   string nonce,
   uint256 timestamp
+)
+```
+
+Request-bound v2 authorizations use the same domain fields with `version` set to `2` and this type:
+
+```text
+PaymentAuthorization(
+  address payer,
+  address recipient,
+  string token,
+  string amount,
+  string nonce,
+  uint256 timestamp,
+  string audience,
+  string method,
+  string resource,
+  string contentType,
+  bytes32 requestHash
 )
 ```
 

--- a/verifier/README.md
+++ b/verifier/README.md
@@ -75,6 +75,8 @@ Request shape:
 }
 ```
 
+The verifier also accepts the staged `authorizationVersion: 2` context, which adds `audience`, `method`, `resource`, `contentType`, and `requestHash`. V2 requests must include a top-level `payer` address that is also covered by the typed-data signature; the verifier rejects the request unless the recovered signer matches it. Legacy requests omit both fields until the gateway cutover.
+
 Successful response:
 
 ```json
@@ -101,6 +103,8 @@ Important error codes:
 | Code | Meaning |
 | --- | --- |
 | `invalid_signature` | Signature recovery failed or signer did not match the context. |
+| `invalid_authorization_context` | The v2 version, binding fields, or payer are missing or malformed. |
+| `signer_mismatch` | The v2 signature does not recover to the claimed payer. |
 | `chain_id_mismatch` | Payment context chain does not match verifier expectation. |
 | `timestamp_expired` | Timestamp is older than `SIGNATURE_EXPIRY_SECONDS`. |
 | `timestamp_future` | Timestamp is beyond allowed future skew. |

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use dashmap::{mapref::entry::Entry, DashMap};
 use ethers::types::transaction::eip712::TypedData;
-use ethers::types::Signature;
+use ethers::types::{Address, Signature};
 
 use ethers::utils::keccak256;
 
@@ -361,6 +361,7 @@ async fn health(headers: HeaderMap) -> (HeaderMap, Json<HealthResponse>) {
 struct VerifyRequest {
     context: PaymentContext,
     signature: String,
+    payer: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -372,6 +373,46 @@ struct PaymentContext {
     #[serde(rename = "chainId")]
     chain_id: u64,
     timestamp: Option<u64>,
+    #[serde(flatten)]
+    authorization: AuthorizationBinding,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+struct AuthorizationBinding {
+    #[serde(
+        rename = "authorizationVersion",
+        default,
+        deserialize_with = "deserialize_authorization_version"
+    )]
+    version: AuthorizationVersion,
+    audience: Option<String>,
+    method: Option<String>,
+    resource: Option<String>,
+    #[serde(rename = "contentType")]
+    content_type: Option<String>,
+    #[serde(rename = "requestHash")]
+    request_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum AuthorizationVersion {
+    #[default]
+    Legacy,
+    V2,
+    Unsupported(u8),
+}
+
+fn deserialize_authorization_version<'de, D>(
+    deserializer: D,
+) -> Result<AuthorizationVersion, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let version = u8::deserialize(deserializer)?;
+    Ok(match version {
+        2 => AuthorizationVersion::V2,
+        version => AuthorizationVersion::Unsupported(version),
+    })
 }
 
 #[derive(Serialize)]
@@ -554,6 +595,126 @@ async fn claim_nonce(state: &AppState, nonce: &str, now: Instant) -> Result<bool
    Signature Verification
 ======================= */
 
+#[derive(Debug)]
+enum AuthorizationContextError {
+    MissingVersion,
+    UnsupportedVersion(u8),
+    MissingField(&'static str),
+}
+
+impl std::fmt::Display for AuthorizationContextError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingVersion => write!(
+                formatter,
+                "authorizationVersion is required when request-binding fields are present"
+            ),
+            Self::UnsupportedVersion(version) => {
+                write!(formatter, "unsupported authorizationVersion {version}")
+            }
+            Self::MissingField(field) => write!(formatter, "v2 context is missing {field}"),
+        }
+    }
+}
+
+fn required_binding_field<'a>(
+    value: &'a Option<String>,
+    name: &'static str,
+) -> Result<&'a str, AuthorizationContextError> {
+    value
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .ok_or(AuthorizationContextError::MissingField(name))
+}
+
+fn build_payment_typed_data(
+    context: &PaymentContext,
+    payer: Option<&str>,
+) -> Result<TypedData, AuthorizationContextError> {
+    let typed_data_json = match context.authorization.version {
+        AuthorizationVersion::Legacy => {
+            if context.authorization.audience.is_some()
+                || context.authorization.method.is_some()
+                || context.authorization.resource.is_some()
+                || context.authorization.content_type.is_some()
+                || context.authorization.request_hash.is_some()
+            {
+                return Err(AuthorizationContextError::MissingVersion);
+            }
+            serde_json::json!({
+                "domain": {
+                    "name": "MicroAI Paygate",
+                    "version": "1",
+                    "chainId": context.chain_id,
+                    "verifyingContract": "0x0000000000000000000000000000000000000000"
+                },
+                "types": {
+                    "Payment": [
+                        { "name": "recipient", "type": "address" },
+                        { "name": "token", "type": "string" },
+                        { "name": "amount", "type": "string" },
+                        { "name": "nonce", "type": "string" },
+                        { "name": "timestamp", "type": "uint256" }
+                    ]
+                },
+                "primaryType": "Payment",
+                "message": {
+                    "recipient": context.recipient,
+                    "token": context.token,
+                    "amount": context.amount,
+                    "nonce": context.nonce,
+                    "timestamp": context.timestamp
+                }
+            })
+        }
+        AuthorizationVersion::V2 => serde_json::json!({
+            "domain": {
+                "name": "MicroAI Paygate",
+                "version": "2",
+                "chainId": context.chain_id,
+                "verifyingContract": "0x0000000000000000000000000000000000000000"
+            },
+            "types": {
+                "PaymentAuthorization": [
+                    { "name": "payer", "type": "address" },
+                    { "name": "recipient", "type": "address" },
+                    { "name": "token", "type": "string" },
+                    { "name": "amount", "type": "string" },
+                    { "name": "nonce", "type": "string" },
+                    { "name": "timestamp", "type": "uint256" },
+                    { "name": "audience", "type": "string" },
+                    { "name": "method", "type": "string" },
+                    { "name": "resource", "type": "string" },
+                    { "name": "contentType", "type": "string" },
+                    { "name": "requestHash", "type": "bytes32" }
+                ]
+            },
+            "primaryType": "PaymentAuthorization",
+            "message": {
+                "payer": payer
+                    .filter(|value| !value.is_empty())
+                    .ok_or(AuthorizationContextError::MissingField("payer"))?,
+                "recipient": context.recipient,
+                "token": context.token,
+                "amount": context.amount,
+                "nonce": context.nonce,
+                "timestamp": context.timestamp,
+                "audience": required_binding_field(&context.authorization.audience, "audience")?,
+                "method": required_binding_field(&context.authorization.method, "method")?,
+                "resource": required_binding_field(&context.authorization.resource, "resource")?,
+                "contentType": required_binding_field(&context.authorization.content_type, "contentType")?,
+                "requestHash": required_binding_field(&context.authorization.request_hash, "requestHash")?
+            }
+        }),
+        AuthorizationVersion::Unsupported(version) => {
+            return Err(AuthorizationContextError::UnsupportedVersion(version));
+        }
+    };
+
+    serde_json::from_value(typed_data_json)
+        .map_err(|_| AuthorizationContextError::MissingField("valid EIP-712 fields"))
+}
+
 async fn verify_signature(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -659,47 +820,58 @@ async fn verify_signature(
         );
     }
 
-    let typed_data_json = serde_json::json!({
-        "domain": {
-            "name": "MicroAI Paygate",
-            "version": "1",
-            "chainId": payload.context.chain_id,
-            "verifyingContract": "0x0000000000000000000000000000000000000000"
-        },
-        "types": {
-            "Payment": [
-                { "name": "recipient", "type": "address" },
-                { "name": "token", "type": "string" },
-                { "name": "amount", "type": "string" },
-                { "name": "nonce", "type": "string" },
-                { "name": "timestamp", "type": "uint256" }
-            ]
-        },
-        "primaryType": "Payment",
-        "message": {
-            "recipient": payload.context.recipient,
-            "token": payload.context.token,
-            "amount": payload.context.amount,
-            "nonce": payload.context.nonce,
-            "timestamp": payload.context.timestamp
-        }
-    });
-
-    let typed_data: TypedData = match serde_json::from_value(typed_data_json) {
+    let typed_data = match build_payment_typed_data(&payload.context, payload.payer.as_deref()) {
         Ok(td) => td,
         Err(e) => {
-            record_verification_failure(&request_start, "typed_data_error");
+            record_verification_failure(&request_start, "invalid_authorization_context");
             return (
                 StatusCode::BAD_REQUEST,
                 res_headers,
                 Json(VerifyResponse {
                     is_valid: false,
                     recovered_address: None,
-                    error: Some(format!("typed data error: {}", e)),
-                    error_code: None,
+                    error: Some(e.to_string()),
+                    error_code: Some("invalid_authorization_context".to_string()),
                 }),
             );
         }
+    };
+
+    let expected_payer = if payload.context.authorization.version == AuthorizationVersion::V2 {
+        let payer = match payload.payer.as_deref() {
+            Some(payer) => payer,
+            None => {
+                record_verification_failure(&request_start, "invalid_authorization_context");
+                return (
+                    StatusCode::BAD_REQUEST,
+                    res_headers,
+                    Json(VerifyResponse {
+                        is_valid: false,
+                        recovered_address: None,
+                        error: Some("v2 verification request is missing payer".to_string()),
+                        error_code: Some("invalid_authorization_context".to_string()),
+                    }),
+                );
+            }
+        };
+        match Address::from_str(payer) {
+            Ok(address) => Some(address),
+            Err(_) => {
+                record_verification_failure(&request_start, "invalid_authorization_context");
+                return (
+                    StatusCode::BAD_REQUEST,
+                    res_headers,
+                    Json(VerifyResponse {
+                        is_valid: false,
+                        recovered_address: None,
+                        error: Some("v2 verification request has invalid payer".to_string()),
+                        error_code: Some("invalid_authorization_context".to_string()),
+                    }),
+                );
+            }
+        }
+    } else {
+        None
     };
 
     let sig = match Signature::from_str(&payload.signature) {
@@ -726,6 +898,19 @@ async fn verify_signature(
 
     match result {
         Ok(addr) => {
+            if expected_payer.is_some_and(|expected| expected != addr) {
+                metrics::record_verification(false, duration, Some("signer_mismatch"));
+                return (
+                    StatusCode::OK,
+                    res_headers,
+                    Json(VerifyResponse {
+                        is_valid: false,
+                        recovered_address: Some(format!("{:?}", addr)),
+                        error: Some("signature does not match payer".to_string()),
+                        error_code: Some("signer_mismatch".to_string()),
+                    }),
+                );
+            }
             match claim_nonce(&state, &payload.context.nonce, Instant::now()).await {
                 Ok(true) => {}
                 Ok(false) => {
@@ -795,7 +980,7 @@ fn record_verification_failure(request_start: &Instant, reason: &'static str) {
 mod tests {
     use super::*;
     use ethers::signers::{LocalWallet, Signer};
-    use ethers::types::transaction::eip712::TypedData;
+    use ethers::types::transaction::eip712::{Eip712, TypedData};
     use std::sync::Arc;
 
     const BASE_SEPOLIA_CHAIN_ID: u64 = 84532;
@@ -1123,9 +1308,129 @@ mod tests {
                 nonce: nonce.into(),
                 chain_id,
                 timestamp: Some(timestamp),
+                authorization: AuthorizationBinding::default(),
             },
             signature: format!("0x{}", hex::encode(sig.to_vec())),
+            payer: None,
         }
+    }
+
+    #[test]
+    fn test_v2_typed_data_matches_shared_request_binding_fixture() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/payment-authorization-v2.json"
+        ))
+        .unwrap();
+        let context: PaymentContext = serde_json::from_value(fixture["context"].clone()).unwrap();
+        let typed_data =
+            build_payment_typed_data(&context, Some(fixture["payer"].as_str().unwrap())).unwrap();
+
+        assert_eq!(
+            format!("0x{}", hex::encode(typed_data.encode_eip712().unwrap())),
+            fixture["expectedTypedDataDigest"].as_str().unwrap()
+        );
+
+        let signature =
+            Signature::from_str(fixture["expectedSignature"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            signature.recover_typed_data(&typed_data).unwrap(),
+            Address::from_str(fixture["expectedSigner"].as_str().unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_v2_context_rejects_missing_binding_fields_and_unknown_versions() {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/payment-authorization-v2.json"
+        ))
+        .unwrap();
+        let mut missing_hash = fixture["context"].clone();
+        missing_hash.as_object_mut().unwrap().remove("requestHash");
+        let context: PaymentContext = serde_json::from_value(missing_hash).unwrap();
+        assert!(build_payment_typed_data(
+            &context,
+            Some("0x14791697260E4c9A71f18484C9f997B308e59325")
+        )
+        .is_err());
+
+        let mut unknown_version = fixture["context"].clone();
+        unknown_version["authorizationVersion"] = serde_json::json!(3);
+        let context: PaymentContext = serde_json::from_value(unknown_version).unwrap();
+        assert!(build_payment_typed_data(
+            &context,
+            Some("0x14791697260E4c9A71f18484C9f997B308e59325")
+        )
+        .is_err());
+    }
+
+    async fn signed_v2_request(nonce: &str) -> VerifyRequest {
+        let fixture: serde_json::Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/payment-authorization-v2.json"
+        ))
+        .unwrap();
+        let mut context: PaymentContext =
+            serde_json::from_value(fixture["context"].clone()).unwrap();
+        context.nonce = nonce.to_string();
+        context.timestamp = Some(now());
+
+        let wallet: LocalWallet =
+            "0123456789012345678901234567890123456789012345678901234567890123"
+                .parse()
+                .unwrap();
+        let payer = format!("{:?}", wallet.address());
+        let signature = wallet
+            .sign_typed_data(&build_payment_typed_data(&context, Some(&payer)).unwrap())
+            .await
+            .unwrap();
+
+        VerifyRequest {
+            context,
+            signature: format!("0x{}", hex::encode(signature.to_vec())),
+            payer: Some(payer),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_signature_accepts_v2_request_binding() {
+        let request = signed_v2_request("v2-valid").await;
+        let (status, _, Json(response)) =
+            verify_signature(State(app_state()), HeaderMap::new(), Ok(Json(request))).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(response.is_valid);
+        assert_eq!(
+            response.recovered_address.as_deref(),
+            Some("0x14791697260e4c9a71f18484c9f997b308e59325")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verify_signature_rejects_tampered_v2_binding_for_claimed_payer() {
+        let mut request = signed_v2_request("v2-tampered").await;
+        request.context.authorization.request_hash = Some(format!("0x{}", "00".repeat(32)));
+
+        let (status, _, Json(response)) =
+            verify_signature(State(app_state()), HeaderMap::new(), Ok(Json(request))).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(!response.is_valid);
+        assert_eq!(response.error_code.as_deref(), Some("signer_mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_verify_signature_rejects_v2_request_without_payer() {
+        let mut request = signed_v2_request("v2-missing-payer").await;
+        request.payer = None;
+
+        let (status, _, Json(response)) =
+            verify_signature(State(app_state()), HeaderMap::new(), Ok(Json(request))).await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(!response.is_valid);
+        assert_eq!(
+            response.error_code.as_deref(),
+            Some("invalid_authorization_context")
+        );
     }
 
     #[test]
@@ -1290,8 +1595,10 @@ mod tests {
                 nonce: "nonce-1".into(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: format!("0x{}", hex::encode(sig.to_vec())),
+            payer: None,
         };
 
         let (status, _, Json(resp)) =
@@ -1348,8 +1655,10 @@ mod tests {
                 nonce: "wrong-chain-nonce".into(),
                 chain_id: 1,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: format!("0x{}", hex::encode(sig.to_vec())),
+            payer: None,
         };
 
         let (status, _, Json(resp)) =
@@ -1380,8 +1689,10 @@ mod tests {
                     nonce: format!("timestamp-{expected_code}"),
                     chain_id: BASE_SEPOLIA_CHAIN_ID,
                     timestamp,
+                    authorization: AuthorizationBinding::default(),
                 },
                 signature: "0x1234567890".to_string(),
+                payer: None,
             };
 
             let (status, _, Json(resp)) =
@@ -1570,8 +1881,10 @@ mod tests {
                 nonce: "nonce".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: "0x1234567890".to_string(),
+            payer: None,
         };
 
         let (status, _headers, Json(_response)) =
@@ -1596,8 +1909,10 @@ mod tests {
                 nonce: "nonce".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: "0x1234567890".to_string(),
+            payer: None,
         };
 
         let (_status, response_headers, _json) =
@@ -1628,8 +1943,10 @@ mod tests {
                 nonce: "nonce".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: "0x1234567890".to_string(),
+            payer: None,
         };
 
         let (_status, response_headers, _json) =
@@ -1700,8 +2017,10 @@ mod tests {
                 nonce: "correlation-test-nonce".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: signature_str,
+            payer: None,
         };
 
         let (status, response_headers, Json(response)) =
@@ -1739,8 +2058,10 @@ mod tests {
                 nonce: "nonce".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(ts),
+                authorization: AuthorizationBinding::default(),
             },
             signature: "0x1234567890".to_string(),
+            payer: None,
         };
 
         let (_status, response_headers, _json) =
@@ -1830,8 +2151,10 @@ mod tests {
                 nonce: "metrics-missing-timestamp".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: None,
+                authorization: AuthorizationBinding::default(),
             },
             signature: "0x1234567890".to_string(),
+            payer: None,
         };
         let (status, _, Json(resp)) = verify_signature(
             State(app_state()),
@@ -1850,8 +2173,10 @@ mod tests {
                 nonce: "metrics-malformed-signature".to_string(),
                 chain_id: BASE_SEPOLIA_CHAIN_ID,
                 timestamp: Some(now()),
+                authorization: AuthorizationBinding::default(),
             },
             signature: "not-a-signature".to_string(),
+            payer: None,
         };
         let (status, _, Json(resp)) = verify_signature(
             State(app_state()),

--- a/verifier/src/main.rs
+++ b/verifier/src/main.rs
@@ -981,10 +981,12 @@ mod tests {
     use super::*;
     use ethers::signers::{LocalWallet, Signer};
     use ethers::types::transaction::eip712::{Eip712, TypedData};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Arc;
 
     const BASE_SEPOLIA_CHAIN_ID: u64 = 84532;
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+    static TEST_NONCE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn app_state() -> AppState {
         app_state_with_window(300, 60)
@@ -1017,6 +1019,14 @@ mod tests {
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs()
+    }
+
+    fn unique_test_nonce() -> String {
+        format!(
+            "{}-{}",
+            now(),
+            TEST_NONCE_COUNTER.fetch_add(1, Ordering::Relaxed)
+        )
     }
 
     fn with_chain_env(
@@ -1392,7 +1402,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_signature_accepts_v2_request_binding() {
-        let request = signed_v2_request("v2-valid").await;
+        let request = signed_v2_request(&unique_test_nonce()).await;
         let (status, _, Json(response)) =
             verify_signature(State(app_state()), HeaderMap::new(), Ok(Json(request))).await;
 
@@ -1406,7 +1416,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_signature_rejects_tampered_v2_binding_for_claimed_payer() {
-        let mut request = signed_v2_request("v2-tampered").await;
+        let mut request = signed_v2_request(&unique_test_nonce()).await;
         request.context.authorization.request_hash = Some(format!("0x{}", "00".repeat(32)));
 
         let (status, _, Json(response)) =
@@ -1419,7 +1429,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_verify_signature_rejects_v2_request_without_payer() {
-        let mut request = signed_v2_request("v2-missing-payer").await;
+        let mut request = signed_v2_request(&unique_test_nonce()).await;
         request.payer = None;
 
         let (status, _, Json(response)) =

--- a/web/src/hooks/use-x402.ts
+++ b/web/src/hooks/use-x402.ts
@@ -10,7 +10,11 @@ import {
   postSummarize,
   readPaymentChallenge,
   readSummarizeSuccess,
+  getSummarizeUrl,
+  getPaymentPayer,
+  serializeSummarizeRequest,
   signPaymentContext,
+  validatePaymentContextForRequest,
 } from "@/lib/x402-client";
 import {
   connectWallet,
@@ -105,7 +109,8 @@ export function useX402() {
     });
 
     try {
-      const first = await postSummarize(text, {
+      const requestBodyText = serializeSummarizeRequest(text);
+      const first = await postSummarize(requestBodyText, {
         "X-Correlation-ID": flow.correlationId,
       });
 
@@ -142,6 +147,12 @@ export function useX402() {
 
       update({ step: "challenge" });
       const context = await readPaymentChallenge(first);
+      validatePaymentContextForRequest(context, {
+        url: getSummarizeUrl(),
+        method: "POST",
+        contentType: "application/json",
+        bodyText: requestBodyText,
+      });
       track(AnalyticsEvent.PaymentChallengeReceived, {
         ...flowProps,
         status_code: first.status,
@@ -211,7 +222,8 @@ export function useX402() {
         ...flowProps,
         chain_id: context.chainId,
       });
-      const signature = await signPaymentContext(signer, context);
+      const payer = await getPaymentPayer(signer, context);
+      const signature = await signPaymentContext(signer, context, payer);
       // The signature prompt is modal and can take arbitrarily long. If the
       // user switched or disconnected accounts while it was open, the wallet's
       // accountsChanged handler has already reset analytics identity — so only
@@ -245,8 +257,8 @@ export function useX402() {
           ...flowProps,
           chain_id: context.chainId,
         });
-        retry = await postSummarize(text, {
-          ...buildSignedHeaders(context, signature),
+        retry = await postSummarize(requestBodyText, {
+          ...buildSignedHeaders(context, signature, payer),
           "X-Correlation-ID": flow.correlationId,
         });
       } finally {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,6 +1,7 @@
 import type { SignedReceipt } from "./verify-receipt";
 
-export type PaymentContext = {
+export type PaymentContextV1 = {
+  authorizationVersion?: never;
   recipient: string;
   token: string;
   amount: string;
@@ -8,6 +9,23 @@ export type PaymentContext = {
   chainId: number;
   timestamp: number;
 };
+
+export type PaymentContextV2 = {
+  authorizationVersion: 2;
+  recipient: string;
+  token: string;
+  amount: string;
+  nonce: string;
+  chainId: number;
+  timestamp: number;
+  audience: string;
+  method: string;
+  resource: string;
+  contentType: string;
+  requestHash: string;
+};
+
+export type PaymentContext = PaymentContextV1 | PaymentContextV2;
 
 export type X402Step =
   | "idle"

--- a/web/src/lib/x402-client.test.ts
+++ b/web/src/lib/x402-client.test.ts
@@ -4,12 +4,27 @@ import authorizationV2Fixture from "../../../tests/fixtures/payment-authorizatio
 import type { PaymentContextV2 } from "./types";
 import {
   buildPaymentTypedData,
+  getSummarizeUrl,
   readPaymentChallenge,
   serializeSummarizeRequest,
   validatePaymentContextForRequest,
 } from "./x402-client";
 
 describe("request-bound payment authorization", () => {
+  it("preserves a configured gateway path prefix", () => {
+    const originalGatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL;
+    process.env.NEXT_PUBLIC_GATEWAY_URL = "https://gateway.example/paygate/";
+    try {
+      expect(getSummarizeUrl()).toBe("https://gateway.example/paygate/api/ai/summarize");
+    } finally {
+      if (originalGatewayUrl === undefined) {
+        delete process.env.NEXT_PUBLIC_GATEWAY_URL;
+      } else {
+        process.env.NEXT_PUBLIC_GATEWAY_URL = originalGatewayUrl;
+      }
+    }
+  });
+
   it("matches the shared v2 typed-data fixture", () => {
     const typedData = buildPaymentTypedData(
       authorizationV2Fixture.context as PaymentContextV2,

--- a/web/src/lib/x402-client.test.ts
+++ b/web/src/lib/x402-client.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { ethers } from "ethers";
+import authorizationV2Fixture from "../../../tests/fixtures/payment-authorization-v2.json";
+import type { PaymentContextV2 } from "./types";
+import {
+  buildPaymentTypedData,
+  readPaymentChallenge,
+  serializeSummarizeRequest,
+  validatePaymentContextForRequest,
+} from "./x402-client";
+
+describe("request-bound payment authorization", () => {
+  it("matches the shared v2 typed-data fixture", () => {
+    const typedData = buildPaymentTypedData(
+      authorizationV2Fixture.context as PaymentContextV2,
+      authorizationV2Fixture.payer,
+    );
+
+    expect(ethers.TypedDataEncoder.hash(typedData.domain, typedData.types, typedData.value)).toBe(
+      authorizationV2Fixture.expectedTypedDataDigest,
+    );
+    expect(
+      ethers.verifyTypedData(
+        typedData.domain,
+        typedData.types,
+        typedData.value,
+        authorizationV2Fixture.expectedSignature,
+      ),
+    ).toBe(authorizationV2Fixture.expectedSigner);
+  });
+
+  it("validates the exact serialized bytes and rejects a changed body", () => {
+    const context = authorizationV2Fixture.context as PaymentContextV2;
+    validatePaymentContextForRequest(context, {
+      url: `${context.audience}${context.resource}`,
+      method: "POST",
+      contentType: "application/json",
+      bodyText: authorizationV2Fixture.bodyText,
+    });
+
+    expect(() =>
+      validatePaymentContextForRequest(context, {
+        url: `${context.audience}${context.resource}`,
+        method: "POST",
+        contentType: "application/json",
+        bodyText: serializeSummarizeRequest("changed"),
+      }),
+    ).toThrow("requestHash");
+  });
+
+  it("rejects unknown, partial, and malformed authorization versions", async () => {
+    const invalidContexts = [
+      { ...authorizationV2Fixture.context, authorizationVersion: 3 },
+      { ...authorizationV2Fixture.context, requestHash: undefined },
+      { ...authorizationV2Fixture.context, authorizationVersion: undefined },
+    ];
+
+    for (const paymentContext of invalidContexts) {
+      await expect(
+        readPaymentChallenge(
+          new Response(JSON.stringify({ paymentContext }), {
+            status: 402,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      ).rejects.toThrow("valid paymentContext");
+    }
+  });
+});

--- a/web/src/lib/x402-client.ts
+++ b/web/src/lib/x402-client.ts
@@ -1,66 +1,232 @@
-import { ethers, type JsonRpcSigner } from "ethers";
-import type { PaymentContext } from "./types";
+import {
+  ethers,
+  type JsonRpcSigner,
+  type TypedDataDomain,
+  type TypedDataField,
+} from "ethers";
+import type { PaymentContext, PaymentContextV2 } from "./types";
 import { validateReceiptFormat, type SignedReceipt } from "./verify-receipt";
 
 const DOMAIN_NAME = "MicroAI Paygate";
-const DOMAIN_VERSION = "1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function isPaymentContext(value: unknown): value is PaymentContext {
+  if (!isRecord(value)) return false;
+  if (
+    !isNonEmptyString(value.recipient) ||
+    !isNonEmptyString(value.token) ||
+    !isNonEmptyString(value.amount) ||
+    !isNonEmptyString(value.nonce) ||
+    !isPositiveSafeInteger(value.chainId) ||
+    !isPositiveSafeInteger(value.timestamp)
+  ) {
+    return false;
+  }
+  if (value.authorizationVersion === undefined) {
+    return !["audience", "method", "resource", "contentType", "requestHash"].some(
+      (field) => field in value,
+    );
+  }
+  return (
+    value.authorizationVersion === 2 &&
+    isNonEmptyString(value.audience) &&
+    isNonEmptyString(value.method) &&
+    isNonEmptyString(value.resource) &&
+    isNonEmptyString(value.contentType) &&
+    typeof value.requestHash === "string" &&
+    /^0x[0-9a-fA-F]{64}$/.test(value.requestHash)
+  );
+}
+
+function isPaymentContextV2(ctx: PaymentContext): ctx is PaymentContextV2 {
+  return "authorizationVersion" in ctx && ctx.authorizationVersion === 2;
+}
 
 export function getGatewayUrl(): string {
   return process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:3000";
 }
 
+export function getSummarizeUrl(): string {
+  return new URL("/api/ai/summarize", getGatewayUrl()).toString();
+}
+
+export function serializeSummarizeRequest(text: string): string {
+  return JSON.stringify({ text });
+}
+
 export async function postSummarize(
-  text: string,
+  bodyText: string,
   headers: Record<string, string> = {},
 ): Promise<Response> {
-  return fetch(`${getGatewayUrl()}/api/ai/summarize`, {
+  return fetch(getSummarizeUrl(), {
     method: "POST",
     headers: { "Content-Type": "application/json", ...headers },
-    body: JSON.stringify({ text }),
+    body: bodyText,
   });
 }
 
 export async function readPaymentChallenge(res: Response): Promise<PaymentContext> {
-  const data = (await res.json()) as { paymentContext?: PaymentContext };
-  if (!data.paymentContext) throw new Error("402 response missing paymentContext");
-  return data.paymentContext;
+  const data: unknown = await res.json();
+  const paymentContext = isRecord(data) ? data.paymentContext : undefined;
+  if (!isPaymentContext(paymentContext)) {
+    throw new Error("402 response missing a valid paymentContext");
+  }
+  return paymentContext;
+}
+
+export type PaymentRequestBinding = {
+  url: string;
+  method: string;
+  contentType: string;
+  bodyText: string;
+};
+
+export async function getPaymentPayer(
+  signer: JsonRpcSigner,
+  ctx: PaymentContext,
+): Promise<string | undefined> {
+  return isPaymentContextV2(ctx) ? signer.getAddress() : undefined;
+}
+
+export function validatePaymentContextForRequest(
+  ctx: PaymentContext,
+  request: PaymentRequestBinding,
+): void {
+  if (!isPaymentContextV2(ctx)) return;
+  const url = new URL(request.url);
+  const expected = {
+    audience: url.origin,
+    method: request.method.toUpperCase(),
+    resource: `${url.pathname}${url.search}`,
+    contentType: request.contentType,
+    requestHash: ethers.sha256(ethers.toUtf8Bytes(request.bodyText)),
+  };
+  for (const field of [
+    "audience",
+    "method",
+    "resource",
+    "contentType",
+    "requestHash",
+  ] as const) {
+    if (ctx[field] !== expected[field]) {
+      throw new Error(`Payment challenge ${field} does not match the outgoing request`);
+    }
+  }
+}
+
+type PaymentTypedData = {
+  domain: TypedDataDomain;
+  types: Record<string, TypedDataField[]>;
+  value: Record<string, unknown>;
+};
+
+export function buildPaymentTypedData(ctx: PaymentContext, payer?: string): PaymentTypedData {
+  if (isPaymentContextV2(ctx)) {
+    if (!payer) {
+      throw new Error("Request-bound payment authorization requires a payer address");
+    }
+    return {
+      domain: {
+        name: DOMAIN_NAME,
+        version: "2",
+        chainId: ctx.chainId,
+        verifyingContract: ethers.ZeroAddress,
+      },
+      types: {
+        PaymentAuthorization: [
+          { name: "payer", type: "address" },
+          { name: "recipient", type: "address" },
+          { name: "token", type: "string" },
+          { name: "amount", type: "string" },
+          { name: "nonce", type: "string" },
+          { name: "timestamp", type: "uint256" },
+          { name: "audience", type: "string" },
+          { name: "method", type: "string" },
+          { name: "resource", type: "string" },
+          { name: "contentType", type: "string" },
+          { name: "requestHash", type: "bytes32" },
+        ],
+      },
+      value: {
+        payer,
+        recipient: ctx.recipient,
+        token: ctx.token,
+        amount: ctx.amount,
+        nonce: ctx.nonce,
+        timestamp: ctx.timestamp,
+        audience: ctx.audience,
+        method: ctx.method,
+        resource: ctx.resource,
+        contentType: ctx.contentType,
+        requestHash: ctx.requestHash,
+      },
+    };
+  }
+
+  return {
+    domain: {
+      name: DOMAIN_NAME,
+      version: "1",
+      chainId: ctx.chainId,
+      verifyingContract: ethers.ZeroAddress,
+    },
+    types: {
+      Payment: [
+        { name: "recipient", type: "address" },
+        { name: "token", type: "string" },
+        { name: "amount", type: "string" },
+        { name: "nonce", type: "string" },
+        { name: "timestamp", type: "uint256" },
+      ],
+    },
+    value: {
+      recipient: ctx.recipient,
+      token: ctx.token,
+      amount: ctx.amount,
+      nonce: ctx.nonce,
+      timestamp: ctx.timestamp,
+    },
+  };
 }
 
 export async function signPaymentContext(
   signer: JsonRpcSigner,
   ctx: PaymentContext,
+  payer?: string,
 ): Promise<string> {
-  const domain = {
-    name: DOMAIN_NAME,
-    version: DOMAIN_VERSION,
-    chainId: ctx.chainId,
-    verifyingContract: ethers.ZeroAddress,
-  };
-  const types = {
-    Payment: [
-      { name: "recipient", type: "address" },
-      { name: "token", type: "string" },
-      { name: "amount", type: "string" },
-      { name: "nonce", type: "string" },
-      { name: "timestamp", type: "uint256" },
-    ],
-  };
-  const value = {
-    recipient: ctx.recipient,
-    token: ctx.token,
-    amount: ctx.amount,
-    nonce: ctx.nonce,
-    timestamp: ctx.timestamp,
-  };
+  const resolvedPayer = payer ?? (await getPaymentPayer(signer, ctx));
+  const { domain, types, value } = buildPaymentTypedData(ctx, resolvedPayer);
   return signer.signTypedData(domain, types, value);
 }
 
-export function buildSignedHeaders(ctx: PaymentContext, signature: string): Record<string, string> {
-  return {
+export function buildSignedHeaders(
+  ctx: PaymentContext,
+  signature: string,
+  payer?: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
     "X-402-Signature": signature,
     "X-402-Nonce": ctx.nonce,
     "X-402-Timestamp": ctx.timestamp.toString(),
   };
+  if (isPaymentContextV2(ctx)) {
+    if (!payer) {
+      throw new Error("Request-bound payment authorization requires a payer address");
+    }
+    headers["X-402-Payer"] = payer;
+  }
+  return headers;
 }
 
 export type SummarizeSuccess = {

--- a/web/src/lib/x402-client.ts
+++ b/web/src/lib/x402-client.ts
@@ -58,7 +58,7 @@ export function getGatewayUrl(): string {
 }
 
 export function getSummarizeUrl(): string {
-  return new URL("/api/ai/summarize", getGatewayUrl()).toString();
+  return `${getGatewayUrl().replace(/\/+$/, "")}/api/ai/summarize`;
 }
 
 export function serializeSummarizeRequest(text: string): string {


### PR DESCRIPTION
## Summary

- add a shared request-bound authorization v2 fixture covering exact body bytes, hash, EIP-712 digest, signature, and signer
- teach the Rust verifier to accept strict v2 contexts while retaining temporary v1 compatibility
- make the web client and TypeScript SDK validate audience, method, encoded resource, content type, and exact serialized body hash before signing
- bind the payer inside the v2 typed-data message and require the recovered signer to match it
- allow the v2 payer retry header through gateway CORS and document `PAYGATE_AUDIENCE`
- ensure fixture changes trigger every dependent CI suite

## Why

The legacy signature authorizes payment metadata but is not bound to the API request that triggered the challenge. A captured authorization can therefore be replayed against different request content.

This is the first staged change: it prepares the verifier and both owned clients without changing the public gateway from v1 yet.

## Compatibility and follow-up

Existing v1 gateway traffic remains compatible. Once the follow-up gateway cutover issues v2 challenges, updated clients fail closed on request-binding mismatches and send the signer-derived payer through `X-402-Payer`.

The gateway cutover must also define minimum-version enforcement so v1 can be retired without leaving a downgrade path.

## Validation

- `cd verifier && cargo fmt -- --check && cargo clippy -- -D warnings && cargo test` — 49 passed
- `cd sdk/typescript && bun run typecheck && bun test && bun run build` — 24 passed, 1 opt-in live test skipped
- `cd web && bun run lint && bun run typecheck && bun run test:unit && bun run build` — 76 passed
- `cd gateway && go vet ./... && go test -count=1 ./...` — passed
- local multi-service E2E — 3 passed, covering challenge, signed verification, and replay rejection
- CodeQL, dependency review, automation validation, Go/Rust/SDK/web CI, Vercel, and Macroscope correctness — passed