### PR TITLE
test: cover SDK UTF-8 base64 helpers

### DIFF
--- a/sdk/typescript/src/__tests__/base64.test.ts
+++ b/sdk/typescript/src/__tests__/base64.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import { decodeBase64ToUtf8, encodeUtf8ToBase64 } from "../base64";
+
+const originalAtob = Object.getOwnPropertyDescriptor(globalThis, "atob");
+const originalBtoa = Object.getOwnPropertyDescriptor(globalThis, "btoa");
+
+function withoutGlobal(name: "atob" | "btoa", callback: () => void): void {
+  const original = Object.getOwnPropertyDescriptor(globalThis, name);
+  try {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    callback();
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, name, original);
+    } else {
+      delete (globalThis as Record<string, unknown>)[name];
+    }
+  }
+}
+
+describe("UTF-8 base64 helpers", () => {
+  it.each([
+    ["ASCII", "Hello, world!"],
+    ["accented text", "Café déjà vu"],
+    ["non-Latin text", "नमस्ते мир"],
+    ["emoji", "Paygate 🚀✅"],
+  ])("round-trips %s", (_label, value) => {
+    expect(decodeBase64ToUtf8(encodeUtf8ToBase64(value))).toBe(value);
+  });
+
+  it("encodes empty text as an empty string", () => {
+    expect(encodeUtf8ToBase64("")).toBe("");
+  });
+
+  it("matches a known base64 fixture", () => {
+    expect(encodeUtf8ToBase64("Hello, world!")).toBe("SGVsbG8sIHdvcmxkIQ==");
+    expect(decodeBase64ToUtf8("SGVsbG8sIHdvcmxkIQ==")).toBe("Hello, world!");
+  });
+
+  it.each(["", " SGVsbG8=", "SGVsbG8= ", "SGVsbG8", "SGVsbG8$", "===="]) (
+    "rejects invalid base64 input %j",
+    (value) => {
+      expect(() => decodeBase64ToUtf8(value)).toThrow("invalid base64");
+    },
+  );
+
+  it("reports a missing atob capability and restores it after the assertion", () => {
+    withoutGlobal("atob", () => {
+      expect(() => decodeBase64ToUtf8("SGVsbG8=")).toThrow(
+        "base64 decoding is unavailable in this runtime",
+      );
+    });
+
+    expect(Object.getOwnPropertyDescriptor(globalThis, "atob")).toEqual(originalAtob);
+  });
+
+  it("reports a missing btoa capability and restores it after the assertion", () => {
+    withoutGlobal("btoa", () => {
+      expect(() => encodeUtf8ToBase64("hello")).toThrow(
+        "base64 encoding is unavailable in this runtime",
+      );
+    });
+
+    expect(Object.getOwnPropertyDescriptor(globalThis, "btoa")).toEqual(originalBtoa);
+  });
+});


### PR DESCRIPTION
## Summary
- Add direct Bun tests for the TypeScript SDK UTF-8 Base64 helpers.
- Cover ASCII, accented, non-Latin, emoji, empty-text encoding, known fixtures, strict invalid-input rejection, and missing atob/btoa runtime errors.
- Restore overridden globals after capability tests.

## Validation
- cd sdk/typescript && bun run test -- src/__tests__/base64.test.ts
- cd sdk/typescript && bun run typecheck
- git diff --check

Fixes #260

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for SDK UTF-8/base64 helper functions
> Adds [base64.test.ts](https://github.com/AnkanMisra/MicroAI-Paygate/pull/307/files#diff-73803b1f1547ad43974865d2324d9d73d06866cb401349e59aee16444af965cf) to cover `encodeUtf8ToBase64` and `decodeBase64ToUtf8`. Tests include round-trip encoding for ASCII, accented, non-Latin, and emoji strings, a known fixture check, rejection of invalid base64 with a specific error message, and behavior when `atob`/`btoa` globals are unavailable. A `withoutGlobal` helper temporarily removes and restores named globals during tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2aff74b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for UTF-8 and Base64 encoding and decoding, including Unicode text, empty input, and known fixtures.
  * Added validation for invalid Base64 data and environments without native Base64 support.
  * Confirmed runtime capabilities are restored after testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->