### PR TITLE
test: cover trusted proxy configuration

### DIFF
--- a/gateway/trusted_proxies_test.go
+++ b/gateway/trusted_proxies_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetTrustedProxies(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{name: "unset", want: nil},
+		{name: "empty", value: "", want: nil},
+		{name: "whitespace only", value: "  \t", want: nil},
+		{
+			name:  "trims entries and preserves order",
+			value: " 10.0.0.1, 2001:db8::/32, , 192.0.2.0/24 ",
+			want:  []string{"10.0.0.1", "2001:db8::/32", "192.0.2.0/24"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TRUSTED_PROXIES", tt.value)
+			require.Equal(t, tt.want, getTrustedProxies())
+		})
+	}
+}
+
+func TestTrustedProxiesGinConfiguration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	valid := []string{"10.0.0.1", "192.0.2.0/24", "2001:db8::/32"}
+	r := gin.New()
+	require.NoError(t, r.SetTrustedProxies(valid))
+
+	invalid := []string{"not-an-ip-or-cidr"}
+	require.Error(t, r.SetTrustedProxies(invalid))
+	require.NoError(t, r.SetTrustedProxies(nil))
+}
+
+func TestTrustedProxiesClientIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name         string
+		trusted      []string
+		remoteAddr   string
+		forwardedFor string
+		want         string
+	}{
+		{
+			name:         "untrusted peer cannot spoof forwarded address",
+			trusted:      []string{"10.0.0.1"},
+			remoteAddr:   "192.0.2.10:1234",
+			forwardedFor: "198.51.100.25",
+			want:         "192.0.2.10",
+		},
+		{
+			name:         "trusted peer may forward client address",
+			trusted:      []string{"10.0.0.1"},
+			remoteAddr:   "10.0.0.1:1234",
+			forwardedFor: "198.51.100.25",
+			want:         "198.51.100.25",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+			require.NoError(t, r.SetTrustedProxies(tt.trusted))
+			r.GET("/client-ip", func(c *gin.Context) {
+				c.String(http.StatusOK, c.ClientIP())
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+			req.RemoteAddr = tt.remoteAddr
+			req.Header.Set("X-Forwarded-For", tt.forwardedFor)
+			response := httptest.NewRecorder()
+
+			r.ServeHTTP(response, req)
+
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Equal(t, tt.want, response.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add table-driven tests for TRUSTED_PROXIES parsing and Gin configuration.
- Cover IPv4/IPv6 addresses and CIDRs, whitespace/empty entries, invalid proxy fallback, and trusted versus untrusted forwarded client IP behavior.

## Validation
- cd gateway && go test ./...
- cd gateway && go vet ./...
- git diff --check

Fixes #261

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for trusted proxy configuration in gateway
> Adds three table-driven tests in [trusted_proxies_test.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/309/files#diff-2d0c46442f7c2ac5e2dff90dbf3f92122e023adb03cbbbdad3395795e8abec38) covering the trusted proxy logic:
> - `TestGetTrustedProxies` verifies that `getTrustedProxies()` returns `nil` for unset/empty/whitespace input and returns a trimmed, order-preserving slice with empty entries removed for comma-separated input.
> - `TestTrustedProxiesGinConfiguration` checks that valid IP/CIDR entries configure `gin.Engine` without error, invalid entries produce an error, and `nil` is accepted.
> - `TestTrustedProxiesClientIP` validates that `ClientIP` returns the peer IP when the remote address is untrusted, and the `X-Forwarded-For` value when it is trusted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 136da12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->