### PR TITLE
test: cover trusted proxy parsing

### DIFF
--- a/gateway/main_test.go
+++ b/gateway/main_test.go
@@ -81,6 +81,141 @@ func TestGetChainIDDefaultBaseSepolia(t *testing.T) {
 	}
 }
 
+func TestGetTrustedProxies(t *testing.T) {
+	tests := []struct {
+		name   string
+		setEnv bool
+		env    string
+		want   []string
+	}{
+		{
+			name: "unset",
+			want: nil,
+		},
+		{
+			name:   "empty",
+			setEnv: true,
+			env:    "",
+			want:   nil,
+		},
+		{
+			name:   "whitespace only",
+			setEnv: true,
+			env:    " \t\n ",
+			want:   nil,
+		},
+		{
+			name:   "trims and removes empty entries",
+			setEnv: true,
+			env:    " 192.0.2.10, , 198.51.100.0/24 ,, 2001:db8::1, 2001:db8:abcd::/48 ",
+			want:   []string{"192.0.2.10", "198.51.100.0/24", "2001:db8::1", "2001:db8:abcd::/48"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv("TRUSTED_PROXIES", tt.env)
+			} else {
+				t.Setenv("TRUSTED_PROXIES", "placeholder")
+				require.NoError(t, os.Unsetenv("TRUSTED_PROXIES"))
+			}
+
+			require.Equal(t, tt.want, getTrustedProxies())
+		})
+	}
+}
+
+func TestTrustedProxyConfiguration(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("valid parsed list applies to gin engine", func(t *testing.T) {
+		t.Setenv("TRUSTED_PROXIES", "192.0.2.10,198.51.100.0/24,2001:db8::1,2001:db8:abcd::/48")
+
+		router := gin.New()
+
+		require.NoError(t, router.SetTrustedProxies(getTrustedProxies()))
+	})
+
+	t.Run("invalid entry is rejected and fallback trusts no proxies", func(t *testing.T) {
+		t.Setenv("TRUSTED_PROXIES", "not-a-proxy")
+
+		router := gin.New()
+		require.Error(t, router.SetTrustedProxies(getTrustedProxies()))
+		require.NoError(t, router.SetTrustedProxies(nil))
+
+		clientIP := serveClientIPRequest(t, router, "198.51.100.10:4321", "203.0.113.7")
+
+		require.Equal(t, "198.51.100.10", clientIP)
+	})
+}
+
+func TestTrustedProxyClientIPBehavior(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		trustedProxies []string
+		remoteAddr     string
+		forwardedFor   string
+		want           string
+	}{
+		{
+			name:           "untrusted direct peer cannot choose forwarded client ip",
+			trustedProxies: []string{"192.0.2.10"},
+			remoteAddr:     "198.51.100.10:4321",
+			forwardedFor:   "203.0.113.7",
+			want:           "198.51.100.10",
+		},
+		{
+			name:           "trusted direct peer resolves forwarded client ip",
+			trustedProxies: []string{"192.0.2.10"},
+			remoteAddr:     "192.0.2.10:4321",
+			forwardedFor:   "203.0.113.7",
+			want:           "203.0.113.7",
+		},
+		{
+			name:           "trusted cidr resolves forwarded client ip",
+			trustedProxies: []string{"192.0.2.0/24"},
+			remoteAddr:     "192.0.2.55:4321",
+			forwardedFor:   "203.0.113.8",
+			want:           "203.0.113.8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			require.NoError(t, router.SetTrustedProxies(tt.trustedProxies))
+
+			clientIP := serveClientIPRequest(t, router, tt.remoteAddr, tt.forwardedFor)
+
+			require.Equal(t, tt.want, clientIP)
+		})
+	}
+}
+
+func serveClientIPRequest(t *testing.T, router *gin.Engine, remoteAddr, forwardedFor string) string {
+	t.Helper()
+
+	router.GET("/client-ip", func(c *gin.Context) {
+		c.String(http.StatusOK, c.ClientIP())
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/client-ip", nil)
+	req.RemoteAddr = remoteAddr
+	if forwardedFor != "" {
+		req.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	return strings.TrimSpace(w.Body.String())
+}
+
 // Rate Limiting Integration Tests
 
 func TestRateLimitMiddleware_AnonymousUser(t *testing.T) {


### PR DESCRIPTION
## Summary
- add table tests for `getTrustedProxies()` covering unset, empty, whitespace-only, and comma-separated proxy values
- verify valid IPv4/IPv4 CIDR/IPv6/IPv6 CIDR proxy lists can be applied to Gin
- verify invalid proxy config fails closed and that `X-Forwarded-For` only affects `ClientIP()` when the direct peer is trusted

Closes #261

## Validation
- `git diff --check` passed
- `go test ./...` not run locally because the Go toolchain is not installed in this Codex environment (`go`/`gofmt` not found on PATH)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for trusted proxy configuration, including empty, whitespace-only, and mixed proxy lists.
  * Added validation that forwarded client IP information is used only when requests originate from trusted proxies or configured networks.
  * Verified trusted proxy settings integrate correctly with request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for trusted proxy parsing in the gateway
> Adds table-driven and integration tests for `getTrustedProxies()` in [gateway/main_test.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/311/files#diff-005700b366011465ee466361b0376941706f1137b07a8d1c11d9368c56ec99d2), covering env var states (unset, empty, whitespace-only, mixed comma-separated list) and gin router integration.
> - `TestGetTrustedProxies` validates that the function returns nil for missing/empty input and a cleaned slice for valid input.
> - `TestTrustedProxyConfiguration` checks that valid proxy lists are accepted by `router.SetTrustedProxies` and that invalid values fall back to nil, returning the direct peer IP instead of `X-Forwarded-For`.
> - `TestTrustedProxyClientIPBehavior` verifies gin client IP resolution for untrusted peers, trusted IPs, and CIDR ranges using a `serveClientIPRequest` helper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b97bf55.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->