### PR TITLE
docs: explain the merge command workflow

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -31,6 +31,15 @@ After the ruleset is active, enable automatic head-branch updates and automatic 
 
 Maintainer `AnkanMisra` can post an exact `/merge` comment on a ready pull request. The bot binds the command to one head commit, updates an out-of-date branch when possible, waits for a current write-access approval, resolved review threads, every applicable CI job, all CodeQL jobs, and Vercel, then squash-merges that exact commit.
 
+### Maintainer usage
+
+1. Review and approve the current pull request head and resolve every review conversation.
+2. Authorize Vercel when a fork deployment requests it.
+3. After the required checks pass, comment exactly `/merge` on the pull request from the `AnkanMisra` account.
+4. Let the bot revalidate the merge gates and squash-merge the authorized head. Do not use GitHub's manual merge button for a normal pull request.
+
+The command is `/merge`, not `/merch`, and must not include other prose. A contributor push or branch update invalidates the old authorization; approve the new head when required and post a fresh `/merge`. Pull requests changing `.github/workflows/**` or `.github/scripts/merge-command.js` remain manual-merge exceptions.
+
 ### Required setup
 
 1. Create a classic personal access token owned by `AnkanMisra` with only the `public_repo` scope and a 90-day expiration. This least-privilege scope is sufficient because MicroAI-Paygate is public; if the repository becomes private, replace it with a `repo`-scoped or appropriately permissioned fine-grained token.

--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -38,7 +38,7 @@ Maintainer `AnkanMisra` can post an exact `/merge` comment on a ready pull reque
 3. After the required checks pass, comment exactly `/merge` on the pull request from the `AnkanMisra` account.
 4. Let the bot revalidate the merge gates and squash-merge the authorized head. Do not use GitHub's manual merge button for a normal pull request.
 
-The command is `/merge`, not `/merch`, and must not include other prose. A contributor push or branch update invalidates the old authorization; approve the new head when required and post a fresh `/merge`. Pull requests changing `.github/workflows/**` or `.github/scripts/merge-command.js` remain manual-merge exceptions.
+The command is `/merge`, not `/merch`, and must not include other prose. If the bot automatically updates an out-of-date branch, approve the updated head when required; the same command keeps running. A contributor push or any other unexpected head change invalidates the authorization and requires a fresh `/merge`. Pull requests changing `.github/workflows/**` or `.github/scripts/merge-command.js` remain manual-merge exceptions.
 
 ### Required setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,13 @@
   `Co-authored-by: codex <codex@users.noreply.github.com>`
 - Keep the trailer in addition to any human or tool co-authors. Do not omit it from docs-only, review-followup, or small cleanup commits when Codex performed the work.
 
+## Maintainer Merge Workflow
+- For a normal pull request, do not use GitHub's manual merge button after checks pass. Once the current head is approved, review conversations are resolved, Vercel is authorized, and required checks are passing, post an exact `/merge` comment from the `AnkanMisra` account.
+- The command must be exactly `/merge`. Similar commands such as `/merch` or comments containing additional prose do not trigger a merge.
+- Treat `/merge` as authorization for the current head commit only. If the contributor pushes or the branch is updated, obtain any required fresh approval and post `/merge` again.
+- The bot revalidates branch freshness, approvals, requested changes, unresolved threads, applicable CI, CodeQL, and Vercel before squash-merging.
+- Pull requests changing `.github/workflows/**` or `.github/scripts/merge-command.js` cannot use the bot and must be merged manually after review.
+
 ## Strict Codex Review Guidelines
 When asked to review a PR, act like a senior engineer doing a pre-merge review. Inspect every changed file and enough surrounding code to trace the affected behavior. Do **not** stop at “no major issues” if there are concrete edge cases, missing tests, docs drift, CI gaps, or maintainability risks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@
 ## Maintainer Merge Workflow
 - For a normal pull request, do not use GitHub's manual merge button after checks pass. Once the current head is approved, review conversations are resolved, Vercel is authorized, and required checks are passing, post an exact `/merge` comment from the `AnkanMisra` account.
 - The command must be exactly `/merge`. Similar commands such as `/merch` or comments containing additional prose do not trigger a merge.
-- Treat `/merge` as authorization for the current head commit only. If the contributor pushes or the branch is updated, obtain any required fresh approval and post `/merge` again.
+- Treat `/merge` as authorization for the current head commit only. If the bot automatically updates an out-of-date branch, obtain any required fresh approval and let the same command continue. If the contributor pushes or the head changes unexpectedly, obtain any required fresh approval and post `/merge` again.
 - The bot revalidates branch freshness, approvals, requested changes, unresolved threads, applicable CI, CodeQL, and Vercel before squash-merging.
 - Pull requests changing `.github/workflows/**` or `.github/scripts/merge-command.js` cannot use the bot and must be merged manually after review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,7 @@ When a pull request is ready to merge:
 2. Authorize Vercel when a fork deployment requests it.
 3. Post an exact `/merge` comment on the pull request from the `AnkanMisra` account. Do not use `/merch`, additional prose, or GitHub's manual merge button for a normal pull request.
 4. Let the Merge Command Bot wait for or revalidate every required check and squash-merge the authorized head.
-5. If the branch or contributor head changes, approve the new head when required and post a fresh `/merge` command.
+5. If the bot automatically updates an out-of-date branch, approve the updated head when required and let the same command continue. If the contributor pushes or the head changes unexpectedly, approve the new head when required and post a fresh `/merge` command.
 
 Pull requests that change `.github/workflows/**` or `.github/scripts/merge-command.js` are intentionally rejected by the bot and must be reviewed and merged manually.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ git checkout -b feat/web-receipt-viewer
 - New pull requests are auto-labeled from changed paths, for example `go`, `rust`, `TypeScript`, `documentation`, and workflow-related labels.
 - PR path labels stay in sync with the current diff when files are added or removed from the branch.
 - Comment `/claim` on an unassigned issue to ask the bot to assign it to you. Writing "assign me" in a new issue body also triggers self-assignment when the issue is still unassigned.
+- After a pull request is approved and its required checks are passing, maintainer `AnkanMisra` merges it by posting an exact `/merge` comment on the pull request. The bot revalidates the approved head commit, review threads, branch freshness, CodeQL, applicable CI, and Vercel before squash-merging.
 - Inactive issues and pull requests are marked stale after 45 days and closed 7 days later unless they have an assignee or exempt labels.
 - Automation is intentionally conservative. Maintainers may adjust labels manually when the bot guesses wrong.
 
@@ -207,6 +208,16 @@ Do not open public issues for vulnerabilities. Follow [SECURITY.md](SECURITY.md)
 ## Maintainer Review Expectations
 
 Reviewers should check the whole affected flow, not only changed lines. Cross-service behavior often touches gateway structs, verifier structs, web typed data, E2E signing, OpenAPI, README diagrams, env examples, Docker, deployment docs, and CI path filters.
+
+When a pull request is ready to merge:
+
+1. Confirm the current head has the required approval, no requested changes, and no unresolved review conversations.
+2. Authorize Vercel when a fork deployment requests it.
+3. Post an exact `/merge` comment on the pull request from the `AnkanMisra` account. Do not use `/merch`, additional prose, or GitHub's manual merge button for a normal pull request.
+4. Let the Merge Command Bot wait for or revalidate every required check and squash-merge the authorized head.
+5. If the branch or contributor head changes, approve the new head when required and post a fresh `/merge` command.
+
+Pull requests that change `.github/workflows/**` or `.github/scripts/merge-command.js` are intentionally rejected by the bot and must be reviewed and merged manually.
 
 Pull requests are easiest to merge when they:
 


### PR DESCRIPTION
## Summary

- document the exact `/merge` command in contributor guidance
- add the maintainer merge procedure to `AGENTS.md`
- clarify head-bound authorization and manual workflow-change exceptions

## Validation

- `node --test .github/scripts/*.test.js`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document the `/merge` command workflow for maintainers
> Adds maintainer-facing documentation across [AUTOMATION.md](https://github.com/AnkanMisra/MicroAI-Paygate/pull/317/files#diff-38d76c8335759210aee4b6a5986223473998a22150980837c727fed892d15538), [AGENTS.md](https://github.com/AnkanMisra/MicroAI-Paygate/pull/317/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9), and [CONTRIBUTING.md](https://github.com/AnkanMisra/MicroAI-Paygate/pull/317/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055) explaining how to merge pull requests via the `/merge` bot command.
>
> - The `/merge` comment must be posted by `AnkanMisra`, be exact (no extra prose), and the bot revalidates approvals, resolved threads, branch freshness, CodeQL, CI, and Vercel before squash-merging.
> - Documents edge cases: automatic branch updates require re-approval but the same command continues; unexpected head changes require a fresh `/merge`.
> - PRs modifying `.github/workflows/**` or `.github/scripts/merge-command.js` are exceptions and must be merged manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa067f2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->