### PR TITLE
fix: implement WriteHeaderNowWithoutLock and synchronize Written access in responseWriterShim

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -242,9 +242,9 @@ func (rws *responseWriterShim) WriteString(s string) (int, error) { return rws.b
 func (rws *responseWriterShim) WriteHeader(statusCode int)        { rws.bw.WriteHeader(statusCode) }
 func (rws *responseWriterShim) WriteHeaderNow()                   { rws.bw.WriteHeaderNow() }
 func (rws *responseWriterShim) Status() int                       { return rws.bw.Status() }
-func (rws *responseWriterShim) Written() bool                     { return rws.bw.wrote }
+func (rws *responseWriterShim) Written() bool                     { rws.bw.mu.RLock(); defer rws.bw.mu.RUnlock(); return rws.bw.wrote }
 func (rws *responseWriterShim) Size() int                         { return rws.bw.buf.Len() }
-func (rws *responseWriterShim) WriteHeaderNowWithoutLock()        {}
+func (rws *responseWriterShim) WriteHeaderNowWithoutLock()        { rws.bw.WriteHeaderNow() }
 
 // Flush flushes the response to the client if the underlying writer
 // supports http.Flusher. This is a no-op otherwise.

--- a/web/src/lib/x402-client.test.ts
+++ b/web/src/lib/x402-client.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import {
+  buildSignedHeaders,
+  getGatewayUrl,
+  postSummarize,
+  readPaymentChallenge,
+  readSummarizeSuccess,
+  safeDecodeReceiptHeader,
+} from "./x402-client";
+import type { PaymentContext } from "./types";
+import type { SignedReceipt } from "./verify-receipt";
+
+const originalGatewayUrl = process.env.NEXT_PUBLIC_GATEWAY_URL;
+const originalFetch = globalThis.fetch;
+
+const paymentContext: PaymentContext = {
+  recipient: "0xrecipient",
+  token: "USDC",
+  amount: "0.001",
+  nonce: "nonce-1",
+  chainId: 84532,
+  timestamp: 1766611200,
+};
+
+const receipt: SignedReceipt = {
+  receipt: {
+    id: "rcpt_web_1",
+    version: "1",
+    timestamp: "2026-06-19T00:00:00Z",
+    payment: {
+      payer: "0xpayer",
+      recipient: "0xrecipient",
+      amount: "0.001",
+      token: "USDC",
+      chainId: 84532,
+      nonce: "nonce-1",
+    },
+    service: {
+      endpoint: "/api/ai/summarize",
+      request_hash: "sha256:request",
+      response_hash: "sha256:response",
+    },
+  },
+  signature: "0xsigned",
+  server_public_key: "0xserver",
+};
+
+function encodeReceipt(value: unknown): string {
+  return btoa(JSON.stringify(value));
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  if (originalGatewayUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_GATEWAY_URL;
+  } else {
+    process.env.NEXT_PUBLIC_GATEWAY_URL = originalGatewayUrl;
+  }
+});
+
+describe("x402 client helpers", () => {
+  it("uses the configured gateway URL and localhost fallback", () => {
+    delete process.env.NEXT_PUBLIC_GATEWAY_URL;
+    expect(getGatewayUrl()).toBe("http://localhost:3000");
+
+    process.env.NEXT_PUBLIC_GATEWAY_URL = "https://gateway.example/";
+    expect(getGatewayUrl()).toBe("https://gateway.example/");
+  });
+
+  it("builds the summarize request while preserving caller headers", async () => {
+    process.env.NEXT_PUBLIC_GATEWAY_URL = "https://gateway.example";
+    const calls: Array<{ input: string; init?: RequestInit }> = [];
+    const fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input: String(input), init });
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    await postSummarize("summarize this", { Authorization: "Bearer test" });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.input).toBe("https://gateway.example/api/ai/summarize");
+    expect(calls[0]?.init).toMatchObject({
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer test",
+      },
+      body: JSON.stringify({ text: "summarize this" }),
+    });
+  });
+
+  it("reads a payment challenge and rejects a missing context", async () => {
+    await expect(
+      readPaymentChallenge(
+        new Response(JSON.stringify({ paymentContext }), { status: 402 }),
+      ),
+    ).resolves.toEqual(paymentContext);
+
+    await expect(
+      readPaymentChallenge(new Response(JSON.stringify({ error: "missing" }), { status: 402 })),
+    ).rejects.toThrow("402 response missing paymentContext");
+  });
+
+  it("builds the exact signed retry headers", () => {
+    expect(buildSignedHeaders(paymentContext, "0xsignature")).toEqual({
+      "X-402-Signature": "0xsignature",
+      "X-402-Nonce": "nonce-1",
+      "X-402-Timestamp": "1766611200",
+    });
+  });
+
+  it("keeps a successful summary with a valid receipt header", async () => {
+    const result = await readSummarizeSuccess(
+      new Response(JSON.stringify({ result: "summary text" }), {
+        status: 200,
+        headers: { "X-402-Receipt": encodeReceipt(receipt) },
+      }),
+    );
+
+    expect(result.summary).toBe("summary text");
+    expect(result.receipt).toEqual(receipt);
+  });
+
+  it("keeps a successful summary when the receipt header is absent", async () => {
+    const result = await readSummarizeSuccess(
+      new Response(JSON.stringify({ result: "summary without receipt" }), { status: 200 }),
+    );
+
+    expect(result).toEqual({ summary: "summary without receipt", receipt: null });
+  });
+
+  it.each([
+    "not-base64",
+    encodeReceipt({ receipt: { id: "rcpt_incomplete" } }),
+    encodeReceipt({ ...receipt, receipt: { ...receipt.receipt, payment: { amount: 1 } } }),
+  ])("drops malformed receipt header %s without throwing", (header) => {
+    expect(safeDecodeReceiptHeader(header)).toBeNull();
+  });
+});


### PR DESCRIPTION
### Fixes

**1. gateway/middleware.go - WriteHeaderNowWithoutLock is a no-op**
The responseWriterShims WriteHeaderNowWithoutLock was empty, breaking the gin.ResponseWriter contract. When Gin internally calls this method, headers were not properly recorded. Fixed by delegating to bufferedWriter.WriteHeaderNow.

**2. gateway/middleware.go - Written accesses bw.wrote without synchronization**
The Written method read bw.wrote without holding bw.mu, creating a data race between the handler goroutine and any reader. Fixed by acquiring a read lock before accessing the field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing payment-protected requests by ensuring response status and headers are captured consistently.
  - Added safer handling for missing or invalid payment receipts, preventing malformed receipt data from causing failures.

- **Tests**
  - Added coverage for gateway configuration, authenticated summarization requests, payment challenges, signed headers, successful responses, and receipt decoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread-safe access and implement `WriteHeaderNowWithoutLock` in `responseWriterShim`
> - `Written()` in [middleware.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/322/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b) now acquires a read lock before reading the `wrote` flag, fixing a potential data race.
> - `WriteHeaderNowWithoutLock()` was previously a no-op; it now calls `WriteHeaderNow()` on the underlying writer.
> - Adds a test suite for the x402 client in [x402-client.test.ts](https://github.com/AnkanMisra/MicroAI-Paygate/pull/322/files#diff-7a4fe1f1c122cfdd725a7b859bfe9f5a1b226b9ed0d88b86533ef4189e39ce7d) covering gateway URL selection, 402 challenge parsing, signed retry headers, and receipt header decoding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3fcf61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->