### PR TITLE
fix: data race in Size() and safe type assertion in handleSummarize

### DIFF
--- a/gateway/main.go
+++ b/gateway/main.go
@@ -438,8 +438,9 @@ func handleSummarize(c *gin.Context) {
 
 	// Check if body already read by middleware
 	if body, exists := c.Get("request_body"); exists {
-		// Cache middleware always sets this as []byte, safe to assert
-		requestBody = body.([]byte)
+		if b, ok := body.([]byte); ok {
+			requestBody = b
+		}
 	}
 
 	// Read body if not already available

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -243,7 +243,7 @@ func (rws *responseWriterShim) WriteHeader(statusCode int)        { rws.bw.Write
 func (rws *responseWriterShim) WriteHeaderNow()                   { rws.bw.WriteHeaderNow() }
 func (rws *responseWriterShim) Status() int                       { return rws.bw.Status() }
 func (rws *responseWriterShim) Written() bool                     { return rws.bw.wrote }
-func (rws *responseWriterShim) Size() int                         { return rws.bw.buf.Len() }
+func (rws *responseWriterShim) Size() int                         { rws.bw.mu.RLock(); defer rws.bw.mu.RUnlock(); return rws.bw.buf.Len() }
 func (rws *responseWriterShim) WriteHeaderNowWithoutLock()        {}
 
 // Flush flushes the response to the client if the underlying writer


### PR DESCRIPTION
## Bug Fixes

### 1. Data race in responseWriterShim.Size()
In `gateway/middleware.go`, `responseWriterShim.Size()` accessed `bw.buf.Len()` without holding the read lock, creating a data race with concurrent handler writes to the buffer via `Write()` (which holds the write lock).

**Fix**: Added `bw.mu.RLock()` / `bw.mu.RUnlock()` around the buffer length read.

### 2. Unsafe type assertion in handleSummarize
In `gateway/main.go`, the type assertion `body.([]byte)` on the Gin context value `request_body` would panic if any middleware or future code path set the key to a non-`[]byte` type.

**Fix**: Replaced with a safe comma-ok type assertion that silently skips if the value is not `[]byte`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix data race in `responseWriterShim.Size` and unsafe type assertion in `handleSummarize`
> - Guards the `c.Get("request_body")` type assertion in [`handleSummarize`](https://github.com/AnkanMisra/MicroAI-Paygate/pull/323/files#diff-937a532e7f5487b02112abe92ad7dcc54f8c7e8160483b899ec8260b5f50470f) so a non-`[]byte` value leaves `requestBody` nil and falls back to reading the HTTP request body, instead of panicking.
> - Wraps the `buf.Len()` read in [`responseWriterShim.Size`](https://github.com/AnkanMisra/MicroAI-Paygate/pull/323/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b) with an `RLock`/`RUnlock` to prevent unsynchronized concurrent access to the response buffer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57d4f15.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling to prevent errors when cached request data has an unexpected format.
  * Improved response processing reliability during concurrent activity by preventing inconsistent buffered response readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->