### PR TITLE
fix: batch-3 - verifier backward compat and thread-safe shim

### DIFF
--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -73,9 +73,16 @@ func isVerifierBusinessRejection(verifyResp *VerifyResponse) bool {
 		"timestamp_missing",
 		"invalid_signature":
 		return true
-	default:
-		return false
 	}
+
+	// Backward compatibility for older verifier responses without error_code.
+	if strings.HasPrefix(verifyResp.Error, "E007") ||
+		strings.HasPrefix(verifyResp.Error, "E008") ||
+		strings.HasPrefix(verifyResp.Error, "E009") {
+		return true
+	}
+
+	return false
 }
 
 func responseCorrelationID(c *gin.Context) string {

--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -242,8 +242,8 @@ func (rws *responseWriterShim) WriteString(s string) (int, error) { return rws.b
 func (rws *responseWriterShim) WriteHeader(statusCode int)        { rws.bw.WriteHeader(statusCode) }
 func (rws *responseWriterShim) WriteHeaderNow()                   { rws.bw.WriteHeaderNow() }
 func (rws *responseWriterShim) Status() int                       { return rws.bw.Status() }
-func (rws *responseWriterShim) Written() bool                     { return rws.bw.wrote }
-func (rws *responseWriterShim) Size() int                         { return rws.bw.buf.Len() }
+func (rws *responseWriterShim) Written() bool                     { rws.bw.mu.RLock(); defer rws.bw.mu.RUnlock(); return rws.bw.wrote }
+func (rws *responseWriterShim) Size() int                         { rws.bw.mu.RLock(); defer rws.bw.mu.RUnlock(); return rws.bw.buf.Len() }
 func (rws *responseWriterShim) WriteHeaderNowWithoutLock()        {}
 
 // Flush flushes the response to the client if the underlying writer


### PR DESCRIPTION
## Batch 3 Bug Fixes

### Bug 1: Missing backward compatibility in isVerifierBusinessRejection
- File: `gateway/errors.go`
- Issue: `isVerifierBusinessRejection` only checked `ErrorCode` field but did not check backward-compatible `Error` prefixes (E007, E008, E009) like `verifierFailureResponse` does
- Impact: Old verifier responses without `error_code` field would NOT be recognized as business rejections, instead treated as infrastructure errors (returned as 502 Bad Gateway instead of proper 400/409 status)

### Bug 2: Data race in responseWriterShim methods
- File: `gateway/middleware.go`
- Issue: `Written()` and `Size()` methods accessed `bufferedWriter` fields without holding the mutex
- Fix: Added RLock/RUnlock to both methods for thread safety
- Impact: Potential data race under concurrent access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy verifier rejection codes to ensure they are classified correctly.
  * Improved reliability when reading buffered response status and size during concurrent request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix verifier backward compatibility and thread-safe shim reads in gateway
> - Extends `isVerifierBusinessRejection` in [errors.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/324/files#diff-a3ecfac3815e0ae44ad28cca2ea219884c8937f3de29ad4bb25b7673ae441089) to handle responses missing `ErrorCode` by checking the `Error` string for `E007`, `E008`, or `E009` prefixes, maintaining backward compatibility with older verifier responses.
> - Adds read locks (`mu.RLock/RUnlock`) to `Written()` and `Size()` in [middleware.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/324/files#diff-703054910891a4db633eca0f42ed779d6b4fa75cd9b3aa4c503e681364201c1b) to prevent data races on concurrent reads of `responseWriterShim` state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b2fecdd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->