### PR TITLE
fix: check response.ok before calling .json()

### DIFF
--- a/web/scripts/deployed-smoke-test.ts
+++ b/web/scripts/deployed-smoke-test.ts
@@ -68,6 +68,9 @@ async function getChallenge(text = "smoke"): Promise<PaymentContext> {
     headers: { "Content-Type": "application/json", Origin: ORIGIN },
     body: JSON.stringify({ text }),
   });
+  if (!r.ok) {
+    throw new Error(`Failed to get challenge: ${r.status} ${r.statusText}`);
+  }
   return (await r.json()).paymentContext as PaymentContext;
 }
 


### PR DESCRIPTION
Add response.ok check before .json() call in deployed-smoke-test.ts to avoid parsing error responses as JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of gateway errors during smoke tests.
  * Error messages now include the HTTP status code and description when summarization requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getChallenge` to check response status before parsing JSON
> In [deployed-smoke-test.ts](https://github.com/AnkanMisra/MicroAI-Paygate/pull/330/files#diff-8da3ccdc73bc1e7d85f0719a61b0d58498ee778703266ffaa3319ec6d2410ced), the `getChallenge` function now throws an `Error` with the HTTP status code and status text if the `/api/ai/summarize` response is not ok, instead of attempting to parse a non-2xx response body as JSON.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9757ee3. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->