### PR TITLE
fix: handle json.Marshal error in OpenRouter provider

### DIFF
--- a/gateway/internal/ai/openrouter.go
+++ b/gateway/internal/ai/openrouter.go
@@ -48,12 +48,15 @@ func NewOpenRouterProvider() *OpenRouterProvider {
 func (p *OpenRouterProvider) Generate(ctx context.Context, text string) (string, error) {
 	prompt := fmt.Sprintf("Summarize this text in 2 sentences: %s", text)
 
-	reqBody, _ := json.Marshal(map[string]interface{}{
+	reqBody, err := json.Marshal(map[string]interface{}{
 		"model": p.model,
 		"messages": []map[string]string{
 			{"role": "user", "content": prompt},
 		},
 	})
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", p.url, bytes.NewBuffer(reqBody))
 	if err != nil {


### PR DESCRIPTION
The json.Marshal error was silently discarded with `_`. If marshaling fails, the request body would be nil/corrupt, causing a cryptic failure at the API call. This fix properly handles and propagates the error.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ignored `json.Marshal` error in `OpenRouterProvider.Generate`
> Previously, [openrouter.go](https://github.com/AnkanMisra/MicroAI-Paygate/pull/331/files#diff-3a9738ffb68688fe0ac5fd80a581a893f9c1364fb4c97ec46bff9f5ec85a27bb) discarded the error from `json.Marshal` when building the request body, meaning a marshalling failure would silently produce an invalid request. The function now returns early with a wrapped error (`"failed to marshal request"`) if marshalling fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c154047.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when preparing AI provider requests.
  * Clearer errors are now returned if request data cannot be formatted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->