### PR TITLE
fix: add HTTP status check before JSON parse

### DIFF
--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -44,7 +44,8 @@ describe("MicroAI Paygate E2E Flow", () => {
     });
 
     expect(res.status).toBe(402);
-    const data = await res.json() as any;
+    if (!res.ok) throw new Error("Request failed");
+const data = await res.json() as any;
     expect(data.error).toBe("Payment Required");
     expect(data.paymentContext).toBeDefined();
     expect(data.paymentContext.nonce).toBeDefined();
@@ -86,7 +87,8 @@ describe("MicroAI Paygate E2E Flow", () => {
     }
 
     expect(res.status).toBe(200);
-    const data = await res.json() as any;
+    if (!res.ok) throw new Error("Request failed");
+const data = await res.json() as any;
     expect(data.result).toBeDefined();
   }, 30000);
 


### PR DESCRIPTION
Added response.ok check before JSON parsing to prevent silent error swallowing on failed HTTP requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by explicitly detecting failed network responses before processing response data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add HTTP status check before JSON parsing in E2E tests
> Guards against parsing error responses as JSON in [tests/e2e.test.ts](https://github.com/AnkanMisra/MicroAI-Paygate/pull/332/files#diff-218a2601c78420abc2108cbc135db7af37f0e5c362ad777a0590571f403cf4c4) by throwing `Error("Request failed")` when `res.ok` is false. The 502 `upstream_unavailable` case is handled as a success path before the guard runs. Risk: tests that previously parsed non-2xx response bodies will now throw instead of asserting on the JSON content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a72020.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->