### PR TITLE
fix: feat: add a Grafana dashboard config (`deploy/grafana/`) for the existing Prometheus metrics — the gateway already exposes `telos_exec_blocks_total`, `telos_network_blocks_total`, and latency metrics at `/metrics`, but there is no pre-built dash

### DIFF
--- a/deploy/grafana/dashboards/microai-paygate.json
+++ b/deploy/grafana/dashboards/microai-paygate.json
@@ -1,0 +1,127 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "type": "datasource",
+      "pluginId": "prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" }
+  ],
+  "title": "MicroAI Paygate — Operations Dashboard",
+  "uid": "microai-paygate-ops",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request Rate (req/s)",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 4, "h": 4 },
+      "targets": [{
+        "expr": "rate(gateway_requests_total[1m])",
+        "legendFormat": "req/s"
+      }]
+    },
+    {
+      "id": 2,
+      "title": "Payment Verification Rate",
+      "type": "stat",
+      "gridPos": { "x": 4, "y": 0, "w": 4, "h": 4 },
+      "targets": [{
+        "expr": "rate(gateway_verifications_total{result='valid'}[1m])",
+        "legendFormat": "verified/s"
+      }]
+    },
+    {
+      "id": 3,
+      "title": "Verification Failures",
+      "type": "stat",
+      "gridPos": { "x": 8, "y": 0, "w": 4, "h": 4 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "red" }}},
+      "targets": [{
+        "expr": "increase(gateway_verifications_total{result='invalid'}[5m])",
+        "legendFormat": "failures (5m)"
+      }]
+    },
+    {
+      "id": 4,
+      "title": "Cache Hit Rate",
+      "type": "stat",
+      "gridPos": { "x": 12, "y": 0, "w": 4, "h": 4 },
+      "targets": [{
+        "expr": "rate(gateway_cache_hits_total[5m]) / (rate(gateway_cache_hits_total[5m]) + rate(gateway_cache_misses_total[5m])) * 100",
+        "legendFormat": "hit rate %"
+      }]
+    },
+    {
+      "id": 5,
+      "title": "Rate Limited Requests",
+      "type": "stat",
+      "gridPos": { "x": 16, "y": 0, "w": 4, "h": 4 },
+      "targets": [{
+        "expr": "increase(gateway_rate_limited_total[5m])",
+        "legendFormat": "rate-limited (5m)"
+      }]
+    },
+    {
+      "id": 6,
+      "title": "API Latency (p50/p95/p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(gateway_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, rate(gateway_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(gateway_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "Verifier Latency (p50/p95/p99)",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 4, "w": 12, "h": 8 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, rate(verifier_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.99, rate(verifier_request_duration_seconds_bucket[5m]))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "Active Drawbridges / Concurrent Requests",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 12, "h": 6 },
+      "targets": [{
+        "expr": "gateway_active_requests",
+        "legendFormat": "active requests"
+      }]
+    },
+    {
+      "id": 9,
+      "title": "AI Provider Response Time",
+      "type": "timeseries",
+      "gridPos": { "x": 12, "y": 12, "w": 12, "h": 6 },
+      "targets": [{
+        "expr": "rate(gateway_ai_duration_seconds_sum[5m]) / rate(gateway_ai_duration_seconds_count[5m])",
+        "legendFormat": "avg AI latency"
+      }]
+    }
+  ]
+}

--- a/deploy/grafana/provisioning/dashboards/microai.yaml
+++ b/deploy/grafana/provisioning/dashboards/microai.yaml
@@ -1,0 +1,9 @@
+# deploy/grafana/provisioning/dashboards/microai.yaml
+apiVersion: 1
+providers:
+  - name: MicroAI Paygate
+    type: file
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/datasources/prometheus.yaml
+++ b/deploy/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,9 @@
+# deploy/grafana/provisioning/datasources/prometheus.yaml
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -1,0 +1,15 @@
+# deploy/prometheus/prometheus.yml
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: microai-gateway
+    static_configs:
+      - targets: ["gateway:3000"]
+    metrics_path: /metrics
+
+  - job_name: microai-verifier
+    static_configs:
+      - targets: ["verifier:3002"]
+    metrics_path: /metrics


### PR DESCRIPTION
Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operations dashboard for monitoring request volume, verification results, cache performance, rate limiting, latency, active requests, and AI provider response times.
  * Added automatic dashboard and Prometheus datasource provisioning.
  * Added monitoring configuration for gateway and verifier service metrics with regular collection and evaluation intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->