### PR TITLE
chore: cover SDK base64 helpers

### DIFF
--- a/sdk/typescript/src/__tests__/base64.test.ts
+++ b/sdk/typescript/src/__tests__/base64.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { decodeBase64ToUtf8, encodeUtf8ToBase64 } from "../base64";
 
-const originalAtob = globalThis.atob;
-const originalBtoa = globalThis.btoa;
+type Base64Global = "atob" | "btoa";
 
-function setGlobalCapability(name: "atob" | "btoa", value: typeof globalThis.atob | undefined) {
+const originalAtobDescriptor = Object.getOwnPropertyDescriptor(globalThis, "atob");
+const originalBtoaDescriptor = Object.getOwnPropertyDescriptor(globalThis, "btoa");
+
+function setGlobalCapability(name: Base64Global, value: typeof globalThis.atob | undefined) {
   Object.defineProperty(globalThis, name, {
     configurable: true,
     value,
@@ -12,9 +14,18 @@ function setGlobalCapability(name: "atob" | "btoa", value: typeof globalThis.ato
   });
 }
 
+function restoreGlobalCapability(name: Base64Global, descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, name);
+}
+
 afterEach(() => {
-  setGlobalCapability("atob", originalAtob);
-  setGlobalCapability("btoa", originalBtoa);
+  restoreGlobalCapability("atob", originalAtobDescriptor);
+  restoreGlobalCapability("btoa", originalBtoaDescriptor);
 });
 
 describe("base64 UTF-8 helpers", () => {

--- a/sdk/typescript/src/__tests__/base64.test.ts
+++ b/sdk/typescript/src/__tests__/base64.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { decodeBase64ToUtf8, encodeUtf8ToBase64 } from "../base64";
+
+const originalAtob = globalThis.atob;
+const originalBtoa = globalThis.btoa;
+
+function setGlobalCapability(name: "atob" | "btoa", value: typeof globalThis.atob | undefined) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  setGlobalCapability("atob", originalAtob);
+  setGlobalCapability("btoa", originalBtoa);
+});
+
+describe("base64 UTF-8 helpers", () => {
+  it("encodes known ASCII fixtures without Node Buffer", () => {
+    expect(encodeUtf8ToBase64("hello")).toBe("aGVsbG8=");
+    expect(encodeUtf8ToBase64("MicroAI Paygate")).toBe("TWljcm9BSSBQYXlnYXRl");
+  });
+
+  it("round-trips ASCII, accented, non-Latin, and emoji text", () => {
+    const cases = [
+      "plain ASCII receipt",
+      "Cr\u00e8me br\u00fbl\u00e9e",
+      "\u0928\u092e\u0938\u094d\u0924\u0947 \u092d\u0941\u0917\u0924\u093e\u0928",
+      "paid receipt \u{1f680}\u2705",
+    ];
+
+    for (const value of cases) {
+      expect(decodeBase64ToUtf8(encodeUtf8ToBase64(value))).toBe(value);
+    }
+  });
+
+  it("decodes valid UTF-8 base64 fixtures", () => {
+    expect(decodeBase64ToUtf8("SGVsbG8sIHdvcmxkIQ==")).toBe("Hello, world!");
+    expect(decodeBase64ToUtf8("4pyF")).toBe("\u2705");
+  });
+
+  it("encodes empty text to an empty base64 payload", () => {
+    expect(encodeUtf8ToBase64("")).toBe("");
+  });
+
+  it("rejects empty, whitespace-padded, invalid-character, and invalid-padding input", () => {
+    for (const value of ["", " aGVsbG8=", "aGVsbG8= ", "abc@", "ab=", "abc==", "a==="]) {
+      expect(() => decodeBase64ToUtf8(value)).toThrow("invalid base64");
+    }
+  });
+
+  it("reports unavailable decoding capability and restores globals", () => {
+    setGlobalCapability("atob", undefined);
+
+    expect(() => decodeBase64ToUtf8("aGVsbG8=")).toThrow(
+      "base64 decoding is unavailable in this runtime",
+    );
+  });
+
+  it("reports unavailable encoding capability and restores globals", () => {
+    setGlobalCapability("btoa", undefined);
+
+    expect(() => encodeUtf8ToBase64("hello")).toThrow(
+      "base64 encoding is unavailable in this runtime",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Added direct Bun unit tests for the TypeScript SDK UTF-8 base64 helpers.
- Covered known ASCII fixtures, accented text, non-Latin text, emoji, empty-text encoding, strict invalid input rejection, and missing `atob` / `btoa` runtime errors.
- Restored modified global capabilities after each test to keep the SDK test suite isolated.

Closes #260

## Type Of Change

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Tests
- [ ] Refactor
- [ ] Deployment/config

## Affected Areas

- [ ] Gateway (`gateway/`)
- [ ] Verifier (`verifier/`)
- [ ] Web (`web/`)
- [ ] E2E/tests (`tests/`, `run_e2e.sh`)
- [ ] Benchmarks (`bench/`)
- [ ] Deployment/config (`deploy/`, Docker, env, workflows)
- [ ] Documentation/community files
- [x] TypeScript SDK (`sdk/typescript/`)

## Contributor Checklist

- [x] I kept the change focused and avoided unrelated refactors.
- [x] I updated README/service docs/OpenAPI/env examples when behavior, config, headers, status codes, or public APIs changed. Not applicable; test-only change.
- [x] I did not commit secrets, private keys, funded wallets, API keys, or real production URLs.
- [x] I checked x402/EIP-712 field parity when touching payment context, signatures, timestamps, nonces, chain IDs, receipts, or wallet flow. Not applicable; no protocol behavior changed.
- [x] I checked Docker/Compose/Fly/Vercel docs when touching ports, service names, health checks, or environment variables. Not applicable.

## Verification

List the exact commands you ran and their result.

```text
cd sdk/typescript && npx --yes bun@1.3.14 run test
Result: passed - 31 pass, 1 skip, 0 fail, 85 expect() calls

cd sdk/typescript && npx --yes bun@1.3.14 run typecheck
Result: passed - tsc --noEmit

git diff --cached --check
Result: passed
```

## Screenshots

Not applicable - SDK unit test coverage only, no visible UI changes.

## Notes For Reviewers

Production code is intentionally unchanged. The new tests import the helper module directly and avoid Node `Buffer` for the behavior under test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for UTF-8 Base64 encoding and decoding.
  * Added validation for Unicode, empty input, invalid data, and environments without native Base64 support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test coverage for SDK base64 UTF-8 helpers
> Adds a Bun test suite in [base64.test.ts](https://github.com/AnkanMisra/MicroAI-Paygate/pull/409/files#diff-73803b1f1547ad43974865d2324d9d73d06866cb401349e59aee16444af965cf) covering `encodeUtf8ToBase64` and `decodeBase64ToUtf8`. Tests include round-trips for ASCII, accented Latin, Devanagari, and emoji strings, known-good decode fixtures, empty string handling, invalid input error cases, and errors when `atob`/`btoa` are unavailable (simulated via `Object.defineProperty`/`Reflect.deleteProperty`).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5061ffe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->